### PR TITLE
Refactored propensity calculations and caching reaction stoichiometries

### DIFF
--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -1,1 +1,1 @@
-from arrow import choose, step, evolve, StochasticSystem
+from arrow import step, evolve, StochasticSystem

--- a/arrow/math.py
+++ b/arrow/math.py
@@ -1,0 +1,37 @@
+
+from __future__ import absolute_import, division, print_function
+
+from itertools import izip
+
+import numpy as np
+
+def choose(n, k):
+    '''
+    Enumerate the number of ways to pick 'k' items from a set of 'n', assuming
+    that items are unique but without concern for order.  E.g. (A, B) and
+    (B, A) from {A, B, C} are only counted once.
+    '''
+
+    combinations = 1.0
+
+    for i in xrange(k):
+        combinations *= (n-i)/(i+1)
+
+    return combinations
+
+
+def multichoose(n, k):
+    '''
+    Enumerate the number of ways to pick elements from different sets of items,
+    where 'n' is a vector of the number of items in each set, and 'k' is a
+    vector of the number of items to choose from each set.
+    '''
+
+    assert n.size == k.size
+
+    combinations = 1.0
+
+    for n_i, k_i in izip(n, k):
+        combinations *= choose(n_i, k_i)
+
+    return combinations

--- a/arrow/test/test_arrow.py
+++ b/arrow/test/test_arrow.py
@@ -120,7 +120,8 @@ if __name__ == '__main__':
     systems = (
         test_equilibration,
         test_dimerization,
-        test_complexation)
+        test_complexation
+        )
 
     if not args.plot:
         if args.complexation:


### PR DESCRIPTION
It was bugging me that propensities were called 'distributions' and combinations were called 'propensities', so I reorganized that logic (and moved all the pure math stuff to a `math` submodule).  Once this was done,  it was easy to start caching the reaction/reactant relationships.  This work might collide with any attempt to make the representation more sparse, but it might also do a good chunk of the work.

I also flattened some logic and replaced some defaults with `None`.