### PR TITLE
Implement Gillespie in C and call from python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.so
 __pycache__
 .python-version
 .pytest_cache

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include arrow/obsidian.h

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include arrow/obsidian.h
+include arrow/mersenne.h

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ the state vector over the course of the simulation.
 Add the following to your `requirements.txt`, or
 `pip install stochastic-arrow`:
 
-    stochastic-arrow==0.0.1
+    stochastic-arrow==0.0.17
 
 ## Usage
 
@@ -58,12 +58,29 @@ state = np.array([1000, 1000, 0, 0])
 # We also specify how long we want the simulation to run. Here we set it to one
 # second.
 duration = 1
+```
 
-# Once we have an initial state and duration, we can run the simulation for the
-# given duration. `evolve` returns the history of the state vector (counts) for
-# each time step, and the history of time steps as they will be in uneven
-# increments throughout the simulation.
-time, counts = system.evolve(state, duration)
+Once we have an initial state and duration, we can run the simulation for the
+given duration. `evolve` returns a dictionary with five keys:
+
+* steps - the number of steps the simulation took
+* time - at what time point each event took place
+* events - the events that occurred
+* occurrences - the number of times each event occurred (derived directly from `events`)
+* outcome - the final state of the system
+
+```python
+result = system.evolve(state, duration)
+```
+
+If you are interested in the history of states for plotting or otherwise, these can be
+derived from the list of events and the stoichiometric matrix, along with the inital
+state. A function `` is provided to do this for you:
+
+```python
+from arrow import reenact_events
+
+history = reenact_events(stoichiometry, result['events'], state)
 ```
 
 ## Testing
@@ -76,4 +93,4 @@ by invoking:
 Also, we have a test that generates plots of various systems which can be run
 like so:
 
-    > python arrow/test/test_arrow.py
+    > python arrow/test/test_arrow.py --plot

--- a/README.md
+++ b/README.md
@@ -31,15 +31,13 @@ matrix of stoichiometrix coefficients) and associated reaction rates:
 from arrow import StochasticSystem
 import numpy as np
 
-# Each column is a reaction and each row is a molecular species (or other
+# Each row is a reaction and each column is a molecular species (or other
 # entity). The first reaction here means that the first and second elements
 # combine to create the third, while the fourth is unaffected.
 stoichiometric_matrix = np.array([
-    [-1, -2, +1],
-    [-1,  0, +1],
-    [+1,  0, -1],
-    [ 0, +1,  0]
-    ])
+    [1, 1, -1, 0],
+    [-2, 0, 0, 1],
+    [-1, -1, 1, 0]], np.int64)
 
 # Each reaction has an associated rate for how probable that reaction is.
 rates = np.array([3.0, 1.0, 1.0])

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ the state vector over the course of the simulation.
 Add the following to your `requirements.txt`, or
 `pip install stochastic-arrow`:
 
-    stochastic-arrow==0.0.17
+    stochastic-arrow==0.0.16
 
 ## Usage
 

--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -1,4 +1,3 @@
-from arrow import derive_reactants, calculate_dependencies, reenact_events, StochasticSystem
-from arrow import evolve, GillespieReference
-
+from reference import derive_reactants, calculate_dependencies, evolve, GillespieReference
+from arrow import reenact_events, StochasticSystem
 import obsidian

--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -1,2 +1,4 @@
 from arrow import evolve, derive_reactants, calculate_dependencies, StochasticSystem
+from arrow import Arrow
+
 import obsidian

--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -1,4 +1,4 @@
-from arrow import evolve, derive_reactants, calculate_dependencies, StochasticSystem
+from arrow import evolve, derive_reactants, calculate_dependencies, reenact_events, StochasticSystem
 from arrow import Arrow
 
 import obsidian

--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -1,2 +1,2 @@
-from arrow import evolve, StochasticSystem
+from arrow import evolve, derive_reactants, calculate_dependencies, StochasticSystem
 import obsidian

--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -1,4 +1,4 @@
-from arrow import evolve, derive_reactants, calculate_dependencies, reenact_events, StochasticSystem
-from arrow import Arrow
+from arrow import derive_reactants, calculate_dependencies, reenact_events, StochasticSystem
+from arrow import evolve, GillespieReference
 
 import obsidian

--- a/arrow/__init__.py
+++ b/arrow/__init__.py
@@ -1,1 +1,2 @@
 from arrow import choose, step, evolve, StochasticSystem
+import obsidian

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -16,11 +16,11 @@ def derive_reactants(stoichiometric_matrix):
         -stoichiometric_matrix[r, reaction_index]
         for reaction_index, r in enumerate(reactants)]
 
-    actors = [
+    involved = [
         np.where(stoichiometry != 0)[0]
         for stoichiometry in stoichiometric_matrix.T]
 
-    return reactants, reactant_stoichiometries, actors
+    return reactants, reactant_stoichiometries, involved
 
 def calculate_dependencies(stoichiometric_matrix):
     dependencies = [
@@ -39,7 +39,7 @@ def step(
         update_reactions=None):
 
     if reactants is None:
-        reactants, reactant_stoichiometries, actors = derive_reactants(
+        reactants, reactant_stoichiometries, involved = derive_reactants(
             stoichiometric_matrix)
 
     if update_reactions is None:
@@ -92,7 +92,7 @@ def evolve(
     events = np.zeros(rates.shape)
 
     if reactants is None or reactant_stoichiometries is None:
-        reactants, reactant_stoichiometries, actors = derive_reactants(
+        reactants, reactant_stoichiometries, involved = derive_reactants(
             stoichiometric_matrix)
 
     if dependencies is None:
@@ -131,7 +131,7 @@ class StochasticSystem(object):
         self.stoichiometric_matrix = stoichiometric_matrix
         self.rates = rates
 
-        reactants, reactant_stoichiometries, actors = derive_reactants(stoichiometric_matrix)
+        reactants, reactant_stoichiometries, involved = derive_reactants(stoichiometric_matrix)
 
         self.reactants = reactants
         self.reactant_stoichiometries = reactant_stoichiometries
@@ -158,7 +158,7 @@ class Arrow(object):
         self.stoichiometry = stoichiometry
         self.rates = rates
 
-        reactants, reactions, actors = derive_reactants(stoichiometry.T)
+        reactants, reactions, involved = derive_reactants(stoichiometry.T)
         dependencies = calculate_dependencies(stoichiometry.T)
 
         self.reactants_lengths = np.array([
@@ -174,11 +174,11 @@ class Arrow(object):
         self.dependencies_indexes = np.insert(self.dependencies_lengths, 0, 0).cumsum()[:-1]
         self.dependencies_flat = np.array(flatten(dependencies))
 
-        self.actors_lengths = np.array([
-            len(actor)
-            for actor in actors])
-        self.actors_indexes = np.insert(self.actors_lengths, 0, 0).cumsum()[:-1]
-        self.actors_flat = np.array(flatten(actors))
+        self.involved_lengths = np.array([
+            len(involve)
+            for involve in involved])
+        self.involved_indexes = np.insert(self.involved_lengths, 0, 0).cumsum()[:-1]
+        self.involved_flat = np.array(flatten(involved))
 
         self.obsidian = obsidian.obsidian(
             self.stoichiometry,
@@ -190,9 +190,9 @@ class Arrow(object):
             self.dependencies_lengths,
             self.dependencies_indexes,
             self.dependencies_flat,
-            self.actors_lengths,
-            self.actors_indexes,
-            self.actors_flat)
+            self.involved_lengths,
+            self.involved_indexes,
+            self.involved_flat)
 
     def evolve(self, duration, state):
         steps, time, events, outcome = self.obsidian.evolve(duration, state)

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -52,6 +52,22 @@ class StochasticSystem(object):
     '''
 
     def __init__(self, stoichiometry, rates):
+		'''
+		This invokes the Obsidian C module with the stoichiometry, reaction rates and a variety of
+		derived values. Once constructed, this can be invoked by calling `evolve` with a duration
+		and initial state, since the stoichiometry will be shared among all calls.
+
+		There are four derived values, each of which is a list of variable length lists. In order
+		to pass this into C, these nested lists are flattened and two associated lists are
+		constructed: one to hold the indexes for each sublist and one to hold the lengths of these
+		sublists. So, to access one of the sublists at index `i`, you can find the start index of
+		the sublist inside of `_flat` with `_indexes[i]`, then iterate through it for the number
+		of elements given by `_lengths[i]`. Strictly speaking this could have been implemented
+		with only the lengths, but that would require iterating through each length to discover
+		the start index of the sublist in the flattened form and since this effort is in order to
+		trade time for space the most expedient approach is chosen.
+		'''
+
         self.stoichiometry = stoichiometry
         self.rates = rates
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -6,7 +6,8 @@ import obsidian
 
 def flatten(l):
     '''
-    Flatten a list by one level: [[1, 2, 3], [[4, 5], 6], [7]] --> [1, 2, 3, [4, 5], 6, 7]
+    Flatten a list by one level:
+        [[1, 2, 3], [[4, 5], 6], [7]] --> [1, 2, 3, [4, 5], 6, 7]
     '''
 
     return [
@@ -16,8 +17,8 @@ def flatten(l):
 
 def flat_indexes(variable):
     '''
-    Take a list of variable length lists and reduce it to a single flat list with associated
-    lengths and indexes, for use by the obsidian C module.
+    Take a list of variable length lists and reduce it to a single flat list with
+    associated lengths and indexes, for use by the obsidian C module.
     '''
 
     lengths = np.array([
@@ -29,8 +30,8 @@ def flat_indexes(variable):
 
 def reenact_events(stoichiometry, events, state):
     '''
-    Reproduce the history of states given an initial state, the history of events and the
-    stoichiometry of those events.
+    Reproduce the history of states given an initial state, the history of events and
+    the stoichiometry of those events.
     '''
 
     history = np.zeros((events.shape[0] + 1, state.shape[0]))
@@ -41,44 +42,47 @@ def reenact_events(stoichiometry, events, state):
 
 class StochasticSystem(object):
     '''
-    This class encapsulates a stochastic system which performs the Gillespie algorithm with
-    a given stoichiometric matrix representing the reactions of the system:
+    This class encapsulates a stochastic system which performs the Gillespie algorithm
+    with a given stoichiometric matrix representing the reactions of the system:
 
         https://en.wikipedia.org/wiki/Gillespie_algorithm
 
-    The stoichiometric matrix has a reaction for each row, with the values in that row encoding
-    how many of each substrate are either consumed or produced by the reaction (and zero everywhere
-    else). 
+    The stoichiometric matrix has a reaction for each row, with the values in that row
+    encoding how many of each substrate are either consumed or produced by the reaction
+   (and zero everywhere else). 
     '''
 
     def __init__(self, stoichiometry, rates):
-		'''
-		This invokes the Obsidian C module with the stoichiometry, reaction rates and a variety of
-		derived values. Once constructed, this can be invoked by calling `evolve` with a duration
-		and initial state, since the stoichiometry will be shared among all calls.
+        '''
+        This invokes the Obsidian C module with the stoichiometry, reaction rates and
+        a variety of derived values. Once constructed, this can be invoked by calling
+        `evolve` with a duration and initial state, since the stoichiometry will be
+        shared among all calls.
 
-		There are four derived values, each of which is a list of variable length lists. In order
-		to pass this into C, these nested lists are flattened and two associated lists are
-		constructed: one to hold the indexes for each sublist and one to hold the lengths of these
-		sublists. So, to access one of the sublists at index `i`, you can find the start index of
-		the sublist inside of `_flat` with `_indexes[i]`, then iterate through it for the number
-		of elements given by `_lengths[i]`. Strictly speaking this could have been implemented
-		with only the lengths, but that would require iterating through each length to discover
-		the start index of the sublist in the flattened form and since this effort is in order to
-		trade time for space the most expedient approach is chosen.
-		'''
+        There are four derived values, each of which is a list of variable length
+        lists. In order to pass this into C, these nested lists are flattened and two
+        associated lists are constructed: one to hold the indexes for each sublist and
+        one to hold the lengths of these sublists. So, to access one of the sublists
+        at index `i`, you can find the start index of the sublist inside of `_flat`
+        with `_indexes[i]`, then iterate through it for the number of elements given
+        by `_lengths[i]`. Strictly speaking this could have been implemented with only
+        the lengths (or the indexes, they are in a way duals of each other), but that
+        would require additional computation. Since this effort is motivated by
+        performance, in order to trade time for space the most expedient approach is
+        chosen, even if it is more verbose.
+        '''
 
         self.stoichiometry = stoichiometry
         self.rates = rates
 
-        reactants, reactions, involved = derive_reactants(stoichiometry)
+        reactants, reactions, substrates = derive_reactants(stoichiometry)
         dependencies = calculate_dependencies(stoichiometry)
 
         self.reactants_flat, self.reactants_lengths, self.reactants_indexes = flat_indexes(reactants)
         self.reactions_flat = np.array(flatten(reactions))
         self.dependencies_flat, self.dependencies_lengths, self.dependencies_indexes = flat_indexes(
             dependencies)
-        self.involved_flat, self.involved_lengths, self.involved_indexes = flat_indexes(involved)
+        self.substrates_flat, self.substrates_lengths, self.substrates_indexes = flat_indexes(substrates)
 
         self.obsidian = obsidian.obsidian(
             self.stoichiometry,
@@ -90,9 +94,9 @@ class StochasticSystem(object):
             self.dependencies_lengths,
             self.dependencies_indexes,
             self.dependencies_flat,
-            self.involved_lengths,
-            self.involved_indexes,
-            self.involved_flat)
+            self.substrates_lengths,
+            self.substrates_indexes,
+            self.substrates_flat)
 
     def evolve(self, duration, state):
         steps, time, events, outcome = self.obsidian.evolve(duration, state)

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -52,7 +52,7 @@ class StochasticSystem(object):
    (and zero everywhere else). 
     '''
 
-    def __init__(self, stoichiometry, rates):
+    def __init__(self, stoichiometry, rates, random_seed=0):
         '''
         This invokes the Obsidian C module with the stoichiometry, reaction rates and
         a variety of derived values. Once constructed, this can be invoked by calling
@@ -75,6 +75,8 @@ class StochasticSystem(object):
         self.stoichiometry = stoichiometry
         self.rates = rates
 
+        self.random_seed = random_seed
+
         reactants, reactions, substrates = derive_reactants(stoichiometry)
         dependencies = calculate_dependencies(stoichiometry)
 
@@ -85,6 +87,7 @@ class StochasticSystem(object):
         self.substrates_flat, self.substrates_lengths, self.substrates_indexes = flat_indexes(substrates)
 
         self.obsidian = obsidian.obsidian(
+            self.random_seed,
             self.stoichiometry,
             self.rates,
             self.reactants_lengths,

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -1,201 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
-from itertools import izip
-
 import numpy as np
-
-from arrow.math import multichoose
+from .reference import derive_reactants, calculate_dependencies
 import obsidian
-
-def derive_reactants(stoichiometry):
-    '''
-    Calculate the various derived values this Gillespie implementation uses extensively
-    to avoid recalculating these values every step or call to `evolve`.
-
-    Args:
-        stoichiometry: A matrix representing all of the reactions the system is capable of.
-            Each row is a reaction, and each column is a substrate.
-
-    Returns:
-        reactants: Array of indexes into each reactant (substrate consumed by the reaction)
-            for each reaction.
-        reactions: The value of the reaction for each reactant involved.
-        involved: Array of indexes for each substrate involved in the reaction (reactant or product).
-    '''
-
-    reactants = [
-        np.where(reaction < 0)[0]
-        for reaction in stoichiometry]
-
-    reactions = [
-        -stoichiometry[reaction, r]
-        for reaction, r in enumerate(reactants)]
-
-    involved = [
-        np.where(reaction != 0)[0]
-        for reaction in stoichiometry]
-
-    return reactants, reactions, involved
-
-def calculate_dependencies(stoichiometry):
-    '''
-    Find out which reactions depend on which other reactions. A dependency exists if one of the
-    reactants or products of a reaction is a substrate involved in another reaction.
-
-    Args:
-        stoichiometry: A matrix representing all of the reactions the system is capable of.
-            Each row is a reaction, and each column is a substrate.
-
-    Returns:
-        dependencies: Array of indexes for each reaction that points to other reactions that will
-            be affected by the reaction.
-    '''
-
-    dependencies = [
-        np.where(np.any(stoichiometry.T[reaction != 0] < 0, 0))[0]
-        for reaction in stoichiometry]
-
-    return dependencies
-
-def step(
-        stoichiometry,
-        rates,
-        state,
-        reactants=None,
-        reactions=None,
-        propensities=None,
-        update_reactions=None):
-    '''
-    Determines which reaction happens next and how much time passes before this event
-    given the stoichiometry, the rates of each reaction, and counts of all substrates.
-    '''
-
-    if reactants is None:
-        reactants, reactions, involved = derive_reactants(
-            stoichiometry)
-
-    if update_reactions is None:
-        n_reactions = stoichiometry.shape[0]
-
-        propensities = np.empty(n_reactions)
-        update_reactions = xrange(n_reactions)
-
-    for reaction in update_reactions:
-        propensities[reaction] = rates[reaction] * multichoose(
-            state[reactants[reaction]],
-            reactions[reaction])
-
-    total = propensities.sum()
-
-    if total == 0:
-        interval = 0
-        outcome = state
-        choice = None
-
-    else:
-        interval = np.random.exponential(1 / total)
-        random = np.random.uniform(0, 1) * total
-
-        progress = 0
-        for choice, span in enumerate(propensities):
-            progress += span
-            if random <= progress:
-                break
-
-        reaction = stoichiometry[choice]
-        outcome = state + reaction
-
-    return interval, outcome, choice, propensities
-
-
-def evolve(
-        stoichiometry,
-        rates,
-        state,
-        duration,
-        reactants=None,
-        reactions=None,
-        dependencies=None):
-    '''
-    Perform a series of steps in the Gillepsie algorithm until the given duration is reached.
-    '''
-
-    now = 0
-    time = [0]
-    counts = [state]
-    propensities = None
-    update_reactions = None
-    events = np.zeros(rates.shape)
-
-    if reactants is None or reactions is None:
-        reactants, reactions, involved = derive_reactants(
-            stoichiometry)
-
-    if dependencies is None:
-        dependencies = calculate_dependencies(stoichiometry)
-
-    while True:
-        interval, state, choice, propensities = step(
-            stoichiometry,
-            rates,
-            state,
-            reactants,
-            reactions,
-            propensities,
-            update_reactions)
-
-        now += interval
-
-        if choice is None or now > duration:
-            break
-
-        time.append(now)
-        counts.append(state)
-
-        events[choice] += 1
-
-        update_reactions = dependencies[choice]
-
-    time = np.array(time)
-    counts = np.array(counts)
-
-    return time, counts, events
-
-class GillespieReference(object):
-    '''
-    This is a pure python implementation of the Gillespie algorithm:
-    https://en.wikipedia.org/wiki/Gillespie_algorithm
-
-    It has been subsumed by the native implementation in C, Obsidian, but is still useful here as
-    reference to the algorithm.
-    '''
-    def __init__(self, stoichiometry, rates):
-        self.stoichiometry = stoichiometry
-        self.rates = rates
-
-        reactants, reactions, involved = derive_reactants(stoichiometry)
-
-        self.reactants = reactants
-        self.reactions = reactions
-        self.dependencies = calculate_dependencies(stoichiometry)
-
-    def step(self, state):
-        return step(self.stoichiometry, self.rates, state)
-
-    def evolve(self, state, duration):
-        return evolve(
-            self.stoichiometry,
-            self.rates,
-            state,
-            duration,
-            reactants=self.reactants,
-            reactions=self.reactions,
-            dependencies=self.dependencies)
 
 def flatten(l):
     '''
     Flatten a list by one level: [[1, 2, 3], [[4, 5], 6], [7]] --> [1, 2, 3, [4, 5], 6, 7]
     '''
+
     return [
         item
         for sublist in l
@@ -219,6 +32,7 @@ def reenact_events(stoichiometry, events, state):
     Reproduce the history of states given an initial state, the history of events and the
     stoichiometry of those events.
     '''
+
     history = np.zeros((events.shape[0] + 1, state.shape[0]))
     history[0] = state
     for index, event in enumerate(events):
@@ -226,6 +40,17 @@ def reenact_events(stoichiometry, events, state):
     return history
 
 class StochasticSystem(object):
+    '''
+    This class encapsulates a stochastic system which performs the Gillespie algorithm with
+    a given stoichiometric matrix representing the reactions of the system:
+
+        https://en.wikipedia.org/wiki/Gillespie_algorithm
+
+    The stoichiometric matrix has a reaction for each row, with the values in that row encoding
+    how many of each substrate are either consumed or produced by the reaction (and zero everywhere
+    else). 
+    '''
+
     def __init__(self, stoichiometry, rates):
         self.stoichiometry = stoichiometry
         self.rates = rates

--- a/arrow/mersenne.c
+++ b/arrow/mersenne.c
@@ -1,0 +1,156 @@
+/* 
+ * The Mersenne Twister pseudo-random number generator (PRNG)
+ *
+ * This is an implementation of fast PRNG called MT19937, meaning it has a
+ * period of 2^19937-1, which is a Mersenne prime.
+ *
+ * This PRNG is fast and suitable for non-cryptographic code.  For instance, it
+ * would be perfect for Monte Carlo simulations, etc.
+ *
+ * For all the details on this algorithm, see the original paper:
+ * http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/ARTICLES/mt.pdf
+ *
+ * Written by Christian Stigen Larsen
+ * Distributed under the modified BSD license.
+ * 2015-02-17, 2017-12-06
+ */
+
+#include <stdio.h>
+#include "mersenne.h"
+
+/*
+ * We have an array of 624 32-bit values, and there are 31 unused bits, so we
+ * have a seed value of 624*32-31 = 19937 bits.
+ */
+static const size_t PERIOD = 397;
+static const size_t DIFF   = TWISTER_SIZE - PERIOD;
+
+static const uint32_t MAGIC = 0x9908b0df;
+
+#define M32 0x80000000 // 32nd MSB
+#define L31 0x7FFFFFFF // 31 LSBs
+
+// State for a singleton Mersenne Twister. If you want to make this into a
+// class, these are what you need to isolate.
+
+/* static MTState state; */
+
+/* #define UNROLL(expr) \ */
+/*   y = (M32 & state.MT[i]) | (L31 & state.MT[i+1]); \ */
+/*   state.MT[i] = state.MT[expr] ^ (y >> 1) ^ (((int32_t(y) << 31) >> 31) & MAGIC); \ */
+/*   ++i; */
+
+static void generate_numbers(MTState * state)
+{
+  /*
+   * For performance reasons, we've unrolled the loop three times, thus
+   * mitigating the need for any modulus operations. Anyway, it seems this
+   * trick is old hat: http://www.quadibloc.com/crypto/co4814.htm
+   */
+
+  size_t i = 0;
+  uint32_t y;
+
+  // i = [0 ... 226]
+  while ( i < DIFF ) {
+    /*
+     * We're doing 226 = 113*2, an even number of steps, so we can safely
+     * unroll one more step here for speed:
+     */
+    y = (M32 & state->MT[i]) | (L31 & state->MT[i+1]);
+    state->MT[i] = state->MT[i+PERIOD] ^ (y >> 1) ^ (((((int32_t) y) << 31) >> 31) & MAGIC);
+    ++i;
+  }
+
+  // i = [227 ... 622]
+  while ( i < TWISTER_SIZE -1 ) {
+    /*
+     * 623-227 = 396 = 2*2*3*3*11, so we can unroll this loop in any number
+     * that evenly divides 396 (2, 4, 6, etc). Here we'll unroll 11 times.
+     */
+    y = (M32 & state->MT[i]) | (L31 & state->MT[i+1]);
+    state->MT[i] = state->MT[i-DIFF] ^ (y >> 1) ^ (((((int32_t) y) << 31) >> 31) & MAGIC);
+    ++i;
+  }
+
+  {
+    // i = 623, last step rolls over
+    y = (M32 & state->MT[TWISTER_SIZE-1]) | (L31 & state->MT[0]);
+    state->MT[TWISTER_SIZE-1] = state->MT[PERIOD-1] ^ (y >> 1) ^ (((((int32_t) y) << 31) >> 31) & MAGIC);
+  }
+
+  // Temper all numbers in a batch
+  for (size_t i = 0; i < TWISTER_SIZE; ++i) {
+    y = state->MT[i];
+    y ^= y >> 11;
+    y ^= y << 7  & 0x9d2c5680;
+    y ^= y << 15 & 0xefc60000;
+    y ^= y >> 18;
+    state->MT_TEMPERED[i] = y;
+  }
+
+  state->index = 0;
+}
+
+void seed(MTState * state, uint32_t value)
+{
+  /*
+   * The equation below is a linear congruential generator (LCG), one of the
+   * oldest known pseudo-random number generator algorithms, in the form
+   * X_(n+1) = = (a*X_n + c) (mod m).
+   *
+   * We've implicitly got m=32 (mask + word size of 32 bits), so there is no
+   * need to explicitly use modulus.
+   *
+   * What is interesting is the multiplier a.  The one we have below is
+   * 0x6c07865 --- 1812433253 in decimal, and is called the Borosh-Niederreiter
+   * multiplier for modulus 2^32.
+   *
+   * It is mentioned in passing in Knuth's THE ART OF COMPUTER
+   * PROGRAMMING, Volume 2, page 106, Table 1, line 13.  LCGs are
+   * treated in the same book, pp. 10-26
+   *
+   * You can read the original paper by Borosh and Niederreiter as well.  It's
+   * called OPTIMAL MULTIPLIERS FOR PSEUDO-RANDOM NUMBER GENERATION BY THE
+   * LINEAR CONGRUENTIAL METHOD (1983) at
+   * http://www.springerlink.com/content/n7765ku70w8857l7/
+   *
+   * You can read about LCGs at:
+   * http://en.wikipedia.org/wiki/Linear_congruential_generator
+   *
+   * From that page, it says: "A common Mersenne twister implementation,
+   * interestingly enough, uses an LCG to generate seed data.",
+   *
+   * Since we're using 32-bits data types for our MT array, we can skip the
+   * masking with 0xFFFFFFFF below.
+   */
+
+  state->MT[0] = value;
+  state->index = TWISTER_SIZE;
+
+  for ( uint_fast32_t i=1; i<TWISTER_SIZE; ++i )
+    state->MT[i] = 0x6c078965*(state->MT[i-1] ^ state->MT[i-1]>>30) + i;
+}
+
+uint32_t rand_u32(MTState * state)
+{
+  if ( state->index == TWISTER_SIZE ) {
+    generate_numbers(state);
+    state->index = 0;
+  }
+
+  return state->MT_TEMPERED[state->index++];
+}
+
+double sample_uniform(MTState * state)
+{
+  uint32_t sample = rand_u32(state);
+  double floating = (double) sample;
+  return floating * 0.5 / M32;
+}
+
+double sample_exponential(MTState * state, double lambda)
+{
+  double sample = sample_uniform(state);
+  return -log(1 - sample) / lambda;
+}

--- a/arrow/mersenne.c
+++ b/arrow/mersenne.c
@@ -16,6 +16,8 @@
  */
 
 #include <stdio.h>
+#include <math.h>
+
 #include "mersenne.h"
 
 /*

--- a/arrow/mersenne.c
+++ b/arrow/mersenne.c
@@ -40,7 +40,7 @@ static const uint32_t MAGIC = 0x9908b0df;
 /*   state.MT[i] = state.MT[expr] ^ (y >> 1) ^ (((int32_t(y) << 31) >> 31) & MAGIC); \ */
 /*   ++i; */
 
-static void generate_numbers(MTState * state)
+static void generate_numbers(MTState *state)
 {
   /*
    * For performance reasons, we've unrolled the loop three times, thus
@@ -92,7 +92,7 @@ static void generate_numbers(MTState * state)
   state->index = 0;
 }
 
-void seed(MTState * state, uint32_t value)
+void seed(MTState *state, uint32_t value)
 {
   /*
    * The equation below is a linear congruential generator (LCG), one of the
@@ -132,7 +132,7 @@ void seed(MTState * state, uint32_t value)
     state->MT[i] = 0x6c078965*(state->MT[i-1] ^ state->MT[i-1]>>30) + i;
 }
 
-uint32_t rand_u32(MTState * state)
+uint32_t rand_u32(MTState *state)
 {
   if ( state->index == TWISTER_SIZE ) {
     generate_numbers(state);
@@ -142,14 +142,14 @@ uint32_t rand_u32(MTState * state)
   return state->MT_TEMPERED[state->index++];
 }
 
-double sample_uniform(MTState * state)
+double sample_uniform(MTState *state)
 {
   uint32_t sample = rand_u32(state);
   double floating = (double) sample;
   return floating * 0.5 / M32;
 }
 
-double sample_exponential(MTState * state, double lambda)
+double sample_exponential(MTState *state, double lambda)
 {
   double sample = sample_uniform(state);
   return -log(1 - sample) / lambda;

--- a/arrow/mersenne.h
+++ b/arrow/mersenne.h
@@ -1,0 +1,41 @@
+/*
+ * The Mersenne Twister pseudo-random number generator (PRNG)
+ *
+ * This is an implementation of fast PRNG called MT19937, meaning it has a
+ * period of 2^19937-1, which is a Mersenne prime.
+ *
+ * This PRNG is fast and suitable for non-cryptographic code.  For instance, it
+ * would be perfect for Monte Carlo simulations, etc.
+ *
+ * For all the details on this algorithm, see the original paper:
+ * http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/ARTICLES/mt.pdf
+ *
+ * Written by Christian Stigen Larsen
+ * Distributed under the modified BSD license.
+ * 2015-02-17, 2017-12-06
+ */
+
+#include <stdint.h>
+
+#ifndef TWISTER_SIZE
+#define TWISTER_SIZE 624
+
+typedef struct MTState MTState;
+struct MTState {
+  uint32_t MT[TWISTER_SIZE];
+  uint32_t MT_TEMPERED[TWISTER_SIZE];
+  size_t index;
+};
+#endif
+
+// Initialize Mersenne Twister with given seed value.
+void seed(MTState * state, uint32_t seed_value);
+
+// Extract a pseudo-random unsigned 32-bit integer in the range 0 ... UINT32_MAX
+uint32_t rand_u32(MTState * state);
+
+// Sample from a uniform distribution
+double sample_uniform(MTState * state);
+
+// Sample from an exponential distribution of a given lambda
+double sample_exponential(MTState * state, double lambda);

--- a/arrow/mersenne.h
+++ b/arrow/mersenne.h
@@ -15,9 +15,11 @@
  * 2015-02-17, 2017-12-06
  */
 
+#ifndef MERSENNE_H
+#define MERSENNE_H
+
 #include <stdint.h>
 
-#ifndef TWISTER_SIZE
 #define TWISTER_SIZE 624
 
 typedef struct MTState MTState;
@@ -26,16 +28,17 @@ struct MTState {
   uint32_t MT_TEMPERED[TWISTER_SIZE];
   size_t index;
 };
-#endif
 
 // Initialize Mersenne Twister with given seed value.
-void seed(MTState * state, uint32_t seed_value);
+void seed(MTState *state, uint32_t seed_value);
 
 // Extract a pseudo-random unsigned 32-bit integer in the range 0 ... UINT32_MAX
-uint32_t rand_u32(MTState * state);
+uint32_t rand_u32(MTState *state);
 
 // Sample from a uniform distribution
-double sample_uniform(MTState * state);
+double sample_uniform(MTState *state);
 
 // Sample from an exponential distribution of a given lambda
-double sample_exponential(MTState * state, double lambda);
+double sample_exponential(MTState *state, double lambda);
+
+#endif

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include "obsidian.h"
+
+int print_array(double * array, int length) {
+  for (int index = 0; index < length; index++)
+    printf("array[%d] = %f\n", index, array[index]);
+  return 0;
+}
+
+evolve_result evolve(double ** stoichiometry, double * rates, double * state, double duration) {
+  evolve_result result = {NULL, NULL, NULL};
+  return result;
+}

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -19,6 +19,51 @@ choose(long n, long k) {
 
 // Perform the Gillespie algorithm with the given stoichiometry, reaction rates and initial
 // state for the provided duration.
+
+// The main arguments to this function are:
+//   * reactions_length: the number of reactions in this system
+//   * substrates_length: the number of substrates this system operates on
+//   * stoichiometry: an array of length `reactions_length * substrates_length` that contains all
+//       the information about the reactions this system performs. Each row is a reaction, and each
+//       column is a substrate, so every entry is the change in counts of that substrate when the
+//       given reaction is performed.
+//   * rates: an array of length `reactions_length` that encodes the base rate for each reaction.
+//       The actual propensity is further dependent on the counts for each reactant in the reaction.
+//   * duration: How long to run the simulation for.
+//   * state: An array of length `substrates_length` that contains the inital count for each
+//       substrate. The outcome of the algorithm will involve an array of the same size that
+//       signifies the counts of each substrate after all the reactions are performed.
+
+// There are four arrays that are derived from the original stoichiometry that are nonetheless passed
+// into this function to avoid recomputing these every step. These values are nested arrays whose
+// subarrays are of variable length. This implementation renders these nested arrays as a single
+// flat array with two corresponding arrays describing the index into each subarray and the length
+// of each subarray (*_indexes and *_lengths respectively).
+
+// So to iterate through a subarray of array `array` at index `sub`:
+
+//   for (long i = 0; i < lengths[sub]; i++) {
+//     long index = indexes[sub];
+//     long value = array[index + i];
+//     ..... (do something with value)
+//   }
+
+// You will see this pattern throughout this function.
+
+// The derived values are:
+//   * reactants: Array of indexes into each reactant (substrate consumed by the reaction)
+//       for each reaction.
+//   * reactions: The value of the reaction for each reactant involved.
+//   * involved: Array of indexes for each substrate involved in the reaction (reactant or product).
+//   * dependencies: Array of indexes for each reaction that points to other reactions that will
+//       be affected by the reaction.
+
+// The return value of this function is a struct of type `evolve_result`, defined in obsidian.h.
+// This has four fields:
+//   * steps: How many steps were performed
+//   * time: An array of length `steps` containing the value at each time point
+//   * events: An array of length `steps` signifying which reaction took place at each time point
+//   * outcome: The final state after all of the reactions have been performed.
 evolve_result
 evolve(int reactions_length,
        int substrates_length,

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -72,28 +72,28 @@ choose(long n, long k) {
 //       each time point
 //   * outcome: The final state after all of the reactions have been performed.
 evolve_result
-evolve(MTState * random_state,
+evolve(MTState *random_state,
 
        int reactions_count,
        int substrates_count,
-       long * stoichiometry,
-       double * rates,
+       long *stoichiometry,
+       double *rates,
 
-       long * reactants_lengths,
-       long * reactants_indexes,
-       long * reactants,
-       long * reactions,
+       long *reactants_lengths,
+       long *reactants_indexes,
+       long *reactants,
+       long *reactions,
        
-       long * dependencies_lengths,
-       long * dependencies_indexes,
-       long * dependencies,
+       long *dependencies_lengths,
+       long *dependencies_indexes,
+       long *dependencies,
 
-       long * substrates_lengths,
-       long * substrates_indexes,
-       long * substrates,
+       long *substrates_lengths,
+       long *substrates_indexes,
+       long *substrates,
 
        double duration,
-       long * state) {
+       long *state) {
 
   // The `event_bounds` will be used to determine how much space to allocate for
   // tracking the evolution of the system's state. If a step is reached that exceeds
@@ -101,14 +101,14 @@ evolve(MTState * random_state,
   long event_bounds = INITIAL_LENGTH;
 
   // Allocate the dynamic arrays that will be used to track the progress of the system
-  double * time = malloc((sizeof (double)) * event_bounds);
-  long * events = malloc((sizeof (long)) * event_bounds);
-  long * outcome = malloc((sizeof (long)) * substrates_count);
+  double *time = malloc((sizeof (double)) * event_bounds);
+  long *events = malloc((sizeof (long)) * event_bounds);
+  long *outcome = malloc((sizeof (long)) * substrates_count);
 
   // Allocate space for the temporary values that will be used entirely within this
   // function
-  double * propensities = malloc((sizeof (double)) * reactions_count);
-  long * update = malloc((sizeof (long)) * reactions_count);
+  double *propensities = malloc((sizeof (double)) * reactions_count);
+  long *update = malloc((sizeof (long)) * reactions_count);
   long update_length = reactions_count;
 
   // Declare the working variables we will use throughout this function
@@ -222,13 +222,13 @@ evolve(MTState * random_state,
       // If our step has advanced beyond the current `event_bounds`, double the
       // `event_bounds` and reallocate these arrays with the new size
       if (step >= event_bounds) {
-        double * new_time = malloc((sizeof (double *)) * event_bounds * 2);
-        memcpy(new_time, time, (sizeof (double *)) * event_bounds);
+        double *new_time = malloc((sizeof (double)) * event_bounds * 2);
+        memcpy(new_time, time, (sizeof (double)) * event_bounds);
         free(time);
         time = new_time;
 
-        long * new_events = malloc((sizeof (long *)) * event_bounds * 2);
-        memcpy(new_events, events, (sizeof (long *)) * event_bounds);
+        long *new_events = malloc((sizeof (long)) * event_bounds * 2);
+        memcpy(new_events, events, (sizeof (long)) * event_bounds);
         free(events);
         events = new_events;
 
@@ -256,7 +256,7 @@ evolve(MTState * random_state,
 
 // Print an array of doubles
 int
-print_array(double * array, int length) {
+print_array(double *array, int length) {
   for (int index = 0; index < length; index++) {
     printf("a[%d] = %f", index, array[index]);
     if (index == length - 1) {
@@ -271,7 +271,7 @@ print_array(double * array, int length) {
 
 // Print an array of longs
 int
-print_long_array(long * array, int length) {
+print_long_array(long *array, int length) {
   for (int index = 0; index < length; index++) {
     printf("a[%d] = %ld", index, array[index]);
     if (index == length - 1) {

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -1,6 +1,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "mersenne.h"
 #include "obsidian.h"
 
 // Initial length of event vectors
@@ -71,7 +72,9 @@ choose(long n, long k) {
 //       each time point
 //   * outcome: The final state after all of the reactions have been performed.
 evolve_result
-evolve(int reactions_count,
+evolve(MTState * random_state,
+
+       int reactions_count,
        int substrates_count,
        long * stoichiometry,
        double * rates,
@@ -98,20 +101,20 @@ evolve(int reactions_count,
   long event_bounds = INITIAL_LENGTH;
 
   // Allocate the dynamic arrays that will be used to track the progress of the system
-  double * time = malloc((sizeof (double *)) * event_bounds);
-  long * events = malloc((sizeof (long *)) * event_bounds);
-  long * outcome = malloc((sizeof (long *)) * substrates_count);
+  double * time = malloc((sizeof (double)) * event_bounds);
+  long * events = malloc((sizeof (long)) * event_bounds);
+  long * outcome = malloc((sizeof (long)) * substrates_count);
 
   // Allocate space for the temporary values that will be used entirely within this
   // function
-  double * propensities = malloc((sizeof (double *)) * reactions_count);
-  long * update = malloc((sizeof (long *)) * reactions_count);
+  double * propensities = malloc((sizeof (double)) * reactions_count);
+  long * update = malloc((sizeof (long)) * reactions_count);
   long update_length = reactions_count;
 
   // Declare the working variables we will use throughout this function
   long substrates_length;
   long reaction, reactant, species, index, involve, count, adjustment;
-  double total, interval, sample, progress, point;
+  double total, interval, point, progress;
   int choice, step = 0, up = 0;
   double now = 0.0;
 
@@ -168,9 +171,12 @@ evolve(int reactions_count,
 
       // First, sample two random values, `point` from a linear distribution and
       // `interval` from an exponential distribution.
-      sample = (double) rand() / RAND_MAX;
-      interval = -log(1 - sample) / total;
-      point = ((double) rand() / RAND_MAX) * total;
+      // sample = (double) rand() / RAND_MAX;
+      // interval = -log(1 - sample) / total;
+      // point = ((double) rand() / RAND_MAX) * total;
+
+      interval = sample_exponential(random_state, total);
+      point = sample_uniform(random_state);
 
       // Based on the random sample, find the event that it corresponds to by
       // iterating through the propensities until we surpass our sampled value

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -5,8 +5,29 @@
 
 int
 print_array(double * array, int length) {
-  for (int index = 0; index < length; index++)
-    printf("array[%d] = %f\n", index, array[index]);
+  for (int index = 0; index < length; index++) {
+    printf("a[%d] = %f", index, array[index]);
+    if (index == length - 1) {
+      printf("\n");
+    } else {
+      printf(", ");
+    }
+  }
+
+  return 0;
+}
+
+int
+print_int_array(int * array, int length) {
+  for (int index = 0; index < length; index++) {
+    printf("a[%d] = %d", index, array[index]);
+    if (index == length - 1) {
+      printf("\n");
+    } else {
+      printf(", ");
+    }
+  }
+
   return 0;
 }
 
@@ -57,8 +78,34 @@ evolve(int reactions_length,
     update[reaction] = reaction;
   }
 
+  int rlength = 0;
+  for (reaction = 0; reaction < reactions_length; reaction++) {
+    rlength += reactants_lengths[reaction];
+  }
+
+  int dlength = 0;
+  for (reaction = 0; reaction < reactions_length; reaction++) {
+    dlength += dependencies_lengths[reaction];
+  }
+
+  printf("reactants_lengths: ");
+  print_int_array(reactants_lengths, reactions_length);
+  printf("reactants_indexes: ");
+  print_int_array(reactants_indexes, reactions_length);
+  printf("reactants: ");
+  print_int_array(reactants, rlength);
+  printf("reactions: ");
+  print_array(reactions, rlength);
+
+  printf("dependencies_lengths: ");
+  print_int_array(dependencies_lengths, reactions_length);
+  printf("dependencies_indexes: ");
+  print_int_array(dependencies_indexes, reactions_length);
+  printf("dependencies: ");
+  print_int_array(dependencies, dlength);
+
   while(now < duration) {
-    printf("step %i", step);
+    printf("step %i\n", step);
 
     for (up = 0; up < update_length; up++) {
       int reaction = update[up];
@@ -70,7 +117,7 @@ evolve(int reactions_length,
       }
     }
 
-    printf("propensities");
+    printf("propensities\n");
     print_array(propensities, reactions_length);
 
     total = 0.0;
@@ -99,8 +146,8 @@ evolve(int reactions_length,
 
       printf("progress: %f - choice: %d - now: %f - duration: %f\n", progress, choice, now, duration);
 
-      if ((choice == -1) || ((now + interval) > duration)) {
-        printf("completing: %d %d", choice == -1, (now + interval) > duration);
+      if (choice == -1 || (now + interval) > duration) {
+        printf("completing: %d %d\n", choice == -1, (now + interval) > duration);
         break;
       }
 
@@ -117,11 +164,13 @@ evolve(int reactions_length,
 
       update_length = dependencies_lengths[choice];
       for (up = 0; up < update_length; up++) {
-        update[up] = dependencies[dependencies_indexes[choice] + up];
+        index = dependencies_indexes[choice] + up;
+        printf("index: %d - dependency: %d\n", index, dependencies[index]);
+        update[up] = dependencies[index];
       }
 
       printf("update\n");
-      print_array(update, update_length);
+      print_int_array(update, update_length);
     }
 
     step += 1;
@@ -129,7 +178,7 @@ evolve(int reactions_length,
 
   print_array(state, substrates_length);
   
-  evolve_result result = {0, time, events, state};
+  evolve_result result = {step, time, events, state};
 
   free(propensities);
   free(update);

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -122,7 +122,7 @@ evolve(MTState *random_state,
       outcome == NULL ||
       propensities == NULL ||
       update == NULL) {
-    printf("allocating memory inside evolve failed: %d", errno);
+    printf("arrow.obsidian.evolve - failed to allocate memory: %d", errno);
 
     free(time);
     free(events);
@@ -244,7 +244,7 @@ evolve(MTState *random_state,
       if (step >= event_bounds) {
         double *new_time = malloc((sizeof (double)) * event_bounds * 2);
         if (new_time == NULL) {
-          printf("failed to allocate memory: %d", errno);
+          printf("arrow.obsidian.evolve - failed to allocate memory: %d", errno);
 
           free(time);
           free(events);
@@ -261,7 +261,7 @@ evolve(MTState *random_state,
 
         long *new_events = malloc((sizeof (long)) * event_bounds * 2);
         if (new_events == NULL) {
-          printf("failed to allocate memory: %d", errno);
+          printf("arrow.obsidian.evolve - failed to allocate memory: %d", errno);
 
           free(time);
           free(events);

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -17,28 +17,32 @@ choose(long n, long k) {
   return combinations;
 }
 
-// Perform the Gillespie algorithm with the given stoichiometry, reaction rates and initial
-// state for the provided duration.
+// Perform the Gillespie algorithm with the given stoichiometry, reaction rates and
+// initial state for the provided duration.
 
 // The main arguments to this function are:
-//   * reactions_length: the number of reactions in this system
-//   * substrates_length: the number of substrates this system operates on
-//   * stoichiometry: an array of length `reactions_length * substrates_length` that contains all
-//       the information about the reactions this system performs. Each row is a reaction, and each
-//       column is a substrate, so every entry is the change in counts of that substrate when the
-//       given reaction is performed.
-//   * rates: an array of length `reactions_length` that encodes the base rate for each reaction.
-//       The actual propensity is further dependent on the counts for each reactant in the reaction.
+//   * reactions_count: the number of reactions in this system.
+//   * substrates_count: the number of substrates this system operates on.
+//   * stoichiometry: an array of length `reactions_count * substrates_count` that
+//       contains all the information about the reactions this system performs. Each
+//       row is a reaction, and each column is a substrate, so every entry is the
+//       change in counts of each substrate when the given reaction is performed.
+//   * rates: an array of length `reactions_count` that encodes the base rate for
+//       each reaction. The actual propensity is further dependent on the counts for
+//       each reactant in the reaction.
 //   * duration: How long to run the simulation for.
-//   * state: An array of length `substrates_length` that contains the inital count for each
-//       substrate. The outcome of the algorithm will involve an array of the same size that
-//       signifies the counts of each substrate after all the reactions are performed.
+//   * state: An array of length `substrates_count` that contains the inital count
+//       for each substrate. The outcome of the algorithm will involve an array of
+//       the same size that signifies the counts of each substrate after all the
+//       reactions are performed.
 
-// There are four arrays that are derived from the original stoichiometry that are nonetheless passed
-// into this function to avoid recomputing these every step. These values are nested arrays whose
-// subarrays are of variable length. This implementation renders these nested arrays as a single
-// flat array with two corresponding arrays describing the index into each subarray and the length
-// of each subarray (*_indexes and *_lengths respectively).
+// There are four arrays that are derived from the original stoichiometry that are
+// nonetheless passed into this function to avoid recomputing these every step. These
+// values are nested arrays whose subarrays are of variable length. Instead of messing
+// around with pointers to pointers (which would still require an accompanying `lengths`
+// array for each nested array), this implementation renders these nested arrays as a
+// single flat array with two corresponding arrays describing the index into each
+// subarray and the length of each subarray (*_indexes and *_lengths respectively).
 
 // So to iterate through a subarray of array `array` at index `sub`:
 
@@ -51,22 +55,24 @@ choose(long n, long k) {
 // You will see this pattern throughout this function.
 
 // The derived values are:
-//   * reactants: Array of indexes into each reactant (substrate consumed by the reaction)
-//       for each reaction.
+//   * reactants: Array of indexes into each reactant (substrate consumed by the
+//       reaction) for each reaction.
 //   * reactions: The value of the reaction for each reactant involved.
-//   * involved: Array of indexes for each substrate involved in the reaction (reactant or product).
-//   * dependencies: Array of indexes for each reaction that points to other reactions that will
-//       be affected by the reaction.
+//   * substrates: Array of indexes for each substrate involved in the reaction
+//       (reactant or product).
+//   * dependencies: Array of indexes for each reaction that points to other reactions
+//       that will be affected by the reaction.
 
-// The return value of this function is a struct of type `evolve_result`, defined in obsidian.h.
-// This has four fields:
+// The return value of this function is a struct of type `evolve_result`, defined in
+// obsidian.h. This has four fields:
 //   * steps: How many steps were performed
 //   * time: An array of length `steps` containing the value at each time point
-//   * events: An array of length `steps` signifying which reaction took place at each time point
+//   * events: An array of length `steps` signifying which reaction took place at
+//       each time point
 //   * outcome: The final state after all of the reactions have been performed.
 evolve_result
-evolve(int reactions_length,
-       int substrates_length,
+evolve(int reactions_count,
+       int substrates_count,
        long * stoichiometry,
        double * rates,
 
@@ -79,44 +85,47 @@ evolve(int reactions_length,
        long * dependencies_indexes,
        long * dependencies,
 
-       long * involved_lengths,
-       long * involved_indexes,
-       long * involved,
+       long * substrates_lengths,
+       long * substrates_indexes,
+       long * substrates,
 
        double duration,
        long * state) {
 
-  // The `event_bounds` will be used to determine how much space to allocate for tracking
-  // the evolution of the system's state. If a step is reached that exceeds `INITIAL_LENGTH`
-  // then these arrays will be reallocated after doubling `event_bounds`.
+  // The `event_bounds` will be used to determine how much space to allocate for
+  // tracking the evolution of the system's state. If a step is reached that exceeds
+  // `event_bounds` then these arrays will be reallocated after doubling `event_bounds`.
   long event_bounds = INITIAL_LENGTH;
 
   // Allocate the dynamic arrays that will be used to track the progress of the system
   double * time = malloc((sizeof (double *)) * event_bounds);
   long * events = malloc((sizeof (long *)) * event_bounds);
-  long * outcome = malloc((sizeof (long *)) * substrates_length);
+  long * outcome = malloc((sizeof (long *)) * substrates_count);
 
-  // Allocate space for the temporary values that will be used entirely within this function
-  double * propensities = malloc((sizeof (double *)) * reactions_length);
-  long * update = malloc((sizeof (long *)) * reactions_length);
-  long update_length = reactions_length;
+  // Allocate space for the temporary values that will be used entirely within this
+  // function
+  double * propensities = malloc((sizeof (double *)) * reactions_count);
+  long * update = malloc((sizeof (long *)) * reactions_count);
+  long update_length = reactions_count;
 
   // Declare the working variables we will use throughout this function
-  long involved_length;
+  long substrates_length;
   long reaction, reactant, species, index, involve, count, adjustment;
   double total, interval, sample, progress, point;
   int choice, step = 0, up = 0;
   double now = 0.0;
 
-  // Copy the initial state that was supplied from outside to the working `outcome` array
-  // we will use to actually apply the reactions and determine the next step's state.
-  for (species = 0; species < substrates_length; species++) {
+  // Copy the initial state that was supplied from outside to the working `outcome`
+  // array we will use to actually apply the reactions and determine the next step's
+  // state.
+  for (species = 0; species < substrates_count; species++) {
     outcome[species] = state[species];
   }
 
-  // The `update` array will hold for each step which propensities need to be updated for the
-  // next time step, based on the dependencies between reactions (sharing substrates).
-  for (reaction = 0; reaction < reactions_length; reaction++) {
+  // The `update` array will hold for each step which propensities need to be updated
+  // for the next time step, based on the dependencies between reactions (sharing
+  // substrates).
+  for (reaction = 0; reaction < reactions_count; reaction++) {
     update[reaction] = reaction;
   }
 
@@ -131,9 +140,9 @@ evolve(int reactions_length,
       reaction = update[up];
       propensities[reaction] = rates[reaction];
 
-      // Go through each reactant and calculate its contribution to the propensity based on
-      // the counts of the corresponding substrate, which is then multiplied by the reaction's
-      // original rate and the contributions from other reactants
+      // Go through each reactant and calculate its contribution to the propensity
+      // based on the counts of the corresponding substrate, which is then multiplied
+      // by the reaction's original rate and the contributions from other reactants
       for (reactant = 0; reactant < reactants_lengths[reaction]; reactant++) {
         index = reactants_indexes[reaction] + reactant;
         count = outcome[reactants[index]];
@@ -143,24 +152,28 @@ evolve(int reactions_length,
 
     // Find the total for all propensities
     total = 0.0;
-    for (reaction = 0; reaction < reactions_length; reaction++) {
+    for (reaction = 0; reaction < reactions_count; reaction++) {
       total += propensities[reaction];
     }
 
-    // If the total is zero, then we have no more reactions to perform and can exit early
+    // If the total is zero, then we have no more reactions to perform and can exit
+    // early
     if (total == 0.0) {
       interval = 0.0;
       choice = -1;
       break;
+
+    // Otherwise we need to find the next reaction to perform. 
     } else {
-      // Otherwise we need to find the next reaction to perform. First, sample two random values
-      // `point` from a linear distribution and `interval` from an exponential distribution.
+
+      // First, sample two random values, `point` from a linear distribution and
+      // `interval` from an exponential distribution.
       sample = (double) rand() / RAND_MAX;
       interval = -log(1 - sample) / total;
       point = ((double) rand() / RAND_MAX) * total;
 
-      // Based on the random sample, find the event that it corresponds to by iterating through
-      // the propensities until we surpass our sampled value
+      // Based on the random sample, find the event that it corresponds to by
+      // iterating through the propensities until we surpass our sampled value
       choice = 0;
       progress = 0.0;
       while(progress + propensities[choice] < point) {
@@ -180,17 +193,17 @@ evolve(int reactions_length,
       time[step] = now;
       events[step] = choice;
 
-      // For each substrate involved in this reaction, update the ongoing state with its
-      // value from the stoichiometric matrix
-      involved_length = involved_lengths[choice];
-      for (involve = 0; involve < involved_length; involve++) {
-        index = involved_indexes[choice] + involve;
-        adjustment = stoichiometry[choice * substrates_length + involved[index]];
-        outcome[involved[index]] += adjustment;
+      // For each substrate involved in this reaction, update the ongoing state
+      // with its value from the stoichiometric matrix
+      substrates_length = substrates_lengths[choice];
+      for (involve = 0; involve < substrates_length; involve++) {
+        index = substrates_indexes[choice] + involve;
+        adjustment = stoichiometry[choice * substrates_count + substrates[index]];
+        outcome[substrates[index]] += adjustment;
       }
 
-      // Find which propensities depend on this reaction and therefore need to be updated
-      // in the next step (the rest of the propensities will not change)
+      // Find which propensities depend on this reaction and therefore need to be
+      // updated in the next step (the rest of the propensities will not change)
       update_length = dependencies_lengths[choice];
       for (up = 0; up < update_length; up++) {
         index = dependencies_indexes[choice] + up;
@@ -200,8 +213,8 @@ evolve(int reactions_length,
       // Advance
       step += 1;
 
-      // If our step has advanced beyond the current `event_bounds`, double the `event_bounds`
-      // and reallocate these arrays with the new size
+      // If our step has advanced beyond the current `event_bounds`, double the
+      // `event_bounds` and reallocate these arrays with the new size
       if (step >= event_bounds) {
         double * new_time = malloc((sizeof (double *)) * event_bounds * 2);
         memcpy(new_time, time, (sizeof (double *)) * event_bounds);
@@ -218,8 +231,9 @@ evolve(int reactions_length,
     }
   }
 
-  // Construct the `evolve_result` from the results of performing steps until either the
-  // desired duration was achieved or there are no more reactions to perform. We return:
+  // Construct the `evolve_result` from the results of performing steps until either
+  // the desired duration was achieved or there are no more reactions to perform.
+  // We return:
   //   * How many steps were performed
   //   * An array of the time of each event
   //   * An array of each event that occurred each time step

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -131,7 +131,7 @@ evolve(MTState *random_state,
   }
 
   // Calculate steps until we reach the provided duration
-  while(now < duration) {
+  while (now < duration) {
 
     // First update all propensities that were affected by the previous event
     for (up = 0; up < update_length; up++) {
@@ -180,7 +180,7 @@ evolve(MTState *random_state,
       // iterating through the propensities until we surpass our sampled value
       choice = 0;
       progress = 0.0;
-      while(progress + propensities[choice] < point) {
+      while (progress + propensities[choice] < point) {
         progress += propensities[choice];
         choice += 1;
       }

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -3,34 +3,6 @@
 #include <stdlib.h>
 #include "obsidian.h"
 
-int
-print_array(double * array, int length) {
-  for (int index = 0; index < length; index++) {
-    printf("a[%d] = %f", index, array[index]);
-    if (index == length - 1) {
-      printf("\n");
-    } else {
-      printf(", ");
-    }
-  }
-
-  return 0;
-}
-
-int
-print_long_array(long * array, int length) {
-  for (int index = 0; index < length; index++) {
-    printf("a[%d] = %ld", index, array[index]);
-    if (index == length - 1) {
-      printf("\n");
-    } else {
-      printf(", ");
-    }
-  }
-
-  return 0;
-}
-
 static int INITIAL_LENGTH = 4000;
 
 double
@@ -169,3 +141,32 @@ evolve(int reactions_length,
 
   return result;
 }
+
+int
+print_array(double * array, int length) {
+  for (int index = 0; index < length; index++) {
+    printf("a[%d] = %f", index, array[index]);
+    if (index == length - 1) {
+      printf("\n");
+    } else {
+      printf(", ");
+    }
+  }
+
+  return 0;
+}
+
+int
+print_long_array(long * array, int length) {
+  for (int index = 0; index < length; index++) {
+    printf("a[%d] = %ld", index, array[index]);
+    if (index == length - 1) {
+      printf("\n");
+    } else {
+      printf(", ");
+    }
+  }
+
+  return 0;
+}
+

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -18,9 +18,9 @@ print_array(double * array, int length) {
 }
 
 int
-print_int_array(int * array, int length) {
+print_long_array(long * array, int length) {
   for (int index = 0; index < length; index++) {
-    printf("a[%d] = %d", index, array[index]);
+    printf("a[%d] = %ld", index, array[index]);
     if (index == length - 1) {
       printf("\n");
     } else {
@@ -49,26 +49,26 @@ evolve(int reactions_length,
        double * stoichiometry,
        double * rates,
 
-       int * reactants_lengths,
-       int * reactants_indexes,
-       int * reactants,
+       long * reactants_lengths,
+       long * reactants_indexes,
+       long * reactants,
        double * reactions,
        
-       int * dependencies_lengths,
-       int * dependencies_indexes,
-       int * dependencies,
+       long * dependencies_lengths,
+       long * dependencies_indexes,
+       long * dependencies,
 
        double duration,
        double * state) {
 
   double * time = malloc((sizeof (double *)) * INITIAL_LENGTH);
-  int * events = malloc((sizeof (int *)) * INITIAL_LENGTH);
+  long * events = malloc((sizeof (long *)) * INITIAL_LENGTH);
 
   double * propensities = malloc((sizeof (double *)) * reactions_length);
-  int * update = malloc((sizeof (int *)) * reactions_length);
-  int update_length = reactions_length;
+  long * update = malloc((sizeof (long *)) * reactions_length);
+  long update_length = reactions_length;
 
-  int reaction, reactant, species, index;
+  long reaction, reactant, species, index;
   double total, interval, sample, progress, point;
   
   int choice, step = 0, up = 0;
@@ -89,26 +89,26 @@ evolve(int reactions_length,
   }
 
   printf("reactants_lengths: ");
-  print_int_array(reactants_lengths, reactions_length);
+  print_long_array(reactants_lengths, reactions_length);
   printf("reactants_indexes: ");
-  print_int_array(reactants_indexes, reactions_length);
+  print_long_array(reactants_indexes, reactions_length);
   printf("reactants: ");
-  print_int_array(reactants, rlength);
+  print_long_array(reactants, rlength);
   printf("reactions: ");
   print_array(reactions, rlength);
 
   printf("dependencies_lengths: ");
-  print_int_array(dependencies_lengths, reactions_length);
+  print_long_array(dependencies_lengths, reactions_length);
   printf("dependencies_indexes: ");
-  print_int_array(dependencies_indexes, reactions_length);
+  print_long_array(dependencies_indexes, reactions_length);
   printf("dependencies: ");
-  print_int_array(dependencies, dlength);
+  print_long_array(dependencies, dlength);
 
   while(now < duration) {
     printf("step %i\n", step);
 
     for (up = 0; up < update_length; up++) {
-      int reaction = update[up];
+      reaction = update[up];
       propensities[reaction] = rates[reaction];
 
       for (reactant = 0; reactant < reactants_lengths[reaction]; reactant++) {
@@ -117,7 +117,7 @@ evolve(int reactions_length,
       }
     }
 
-    printf("propensities\n");
+    printf("propensities: ");
     print_array(propensities, reactions_length);
 
     total = 0.0;
@@ -165,12 +165,11 @@ evolve(int reactions_length,
       update_length = dependencies_lengths[choice];
       for (up = 0; up < update_length; up++) {
         index = dependencies_indexes[choice] + up;
-        printf("index: %d - dependency: %d\n", index, dependencies[index]);
         update[up] = dependencies[index];
       }
 
       printf("update\n");
-      print_int_array(update, update_length);
+      print_long_array(update, update_length);
     }
 
     step += 1;

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -88,24 +88,24 @@ evolve(int reactions_length,
     dlength += dependencies_lengths[reaction];
   }
 
-  printf("reactants_lengths: ");
-  print_long_array(reactants_lengths, reactions_length);
-  printf("reactants_indexes: ");
-  print_long_array(reactants_indexes, reactions_length);
-  printf("reactants: ");
-  print_long_array(reactants, rlength);
-  printf("reactions: ");
-  print_array(reactions, rlength);
+  /* printf("reactants_lengths: "); */
+  /* print_long_array(reactants_lengths, reactions_length); */
+  /* printf("reactants_indexes: "); */
+  /* print_long_array(reactants_indexes, reactions_length); */
+  /* printf("reactants: "); */
+  /* print_long_array(reactants, rlength); */
+  /* printf("reactions: "); */
+  /* print_array(reactions, rlength); */
 
-  printf("dependencies_lengths: ");
-  print_long_array(dependencies_lengths, reactions_length);
-  printf("dependencies_indexes: ");
-  print_long_array(dependencies_indexes, reactions_length);
-  printf("dependencies: ");
-  print_long_array(dependencies, dlength);
+  /* printf("dependencies_lengths: "); */
+  /* print_long_array(dependencies_lengths, reactions_length); */
+  /* printf("dependencies_indexes: "); */
+  /* print_long_array(dependencies_indexes, reactions_length); */
+  /* printf("dependencies: "); */
+  /* print_long_array(dependencies, dlength); */
 
   while(now < duration) {
-    printf("step %i\n", step);
+    /* printf("step %i\n", step); */
 
     for (up = 0; up < update_length; up++) {
       reaction = update[up];
@@ -117,15 +117,15 @@ evolve(int reactions_length,
       }
     }
 
-    printf("propensities: ");
-    print_array(propensities, reactions_length);
+    /* printf("propensities: "); */
+    /* print_array(propensities, reactions_length); */
 
     total = 0.0;
     for (reaction = 0; reaction < reactions_length; reaction++) {
       total += propensities[reaction];
     }
 
-    printf("total: %f\n", total);
+    /* printf("total: %f\n", total); */
 
     if (total == 0) {
       interval = 0.0;
@@ -135,7 +135,7 @@ evolve(int reactions_length,
       interval = -log(1 - sample) / total;
       point = ((double) rand() / RAND_MAX) * total;
 
-      printf("sample: %f - interval: %f - point: %f\n", sample, interval, point);
+      /* printf("sample: %f - interval: %f - point: %f\n", sample, interval, point); */
 
       choice = 0;
       progress = 0.0;
@@ -144,16 +144,16 @@ evolve(int reactions_length,
         choice += 1;
       }
 
-      printf("progress: %f - choice: %d - now: %f - duration: %f\n", progress, choice, now, duration);
+      /* printf("progress: %f - choice: %d - now: %f - duration: %f\n", progress, choice, now, duration); */
 
       if (choice == -1 || (now + interval) > duration) {
-        printf("completing: %d %d\n", choice == -1, (now + interval) > duration);
+        /* printf("completing: %d %d\n", choice == -1, (now + interval) > duration); */
         break;
       }
 
       now += interval;
 
-      printf("new time: %f\n", now);
+      /* printf("new time: %f\n", now); */
 
       time[step] = now;
       events[step] = choice;
@@ -168,14 +168,14 @@ evolve(int reactions_length,
         update[up] = dependencies[index];
       }
 
-      printf("update\n");
-      print_long_array(update, update_length);
+      /* printf("update\n"); */
+      /* print_long_array(update, update_length); */
     }
 
     step += 1;
   }
 
-  print_array(state, substrates_length);
+  /* print_array(state, substrates_length); */
   
   evolve_result result = {step, time, events, state};
 

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -78,17 +78,17 @@ evolve(int reactions_length,
       total += propensities[reaction];
     }
 
-    printf("total: %d\n", total);
+    printf("total: %f\n", total);
 
     if (total == 0) {
       interval = 0.0;
       choice = -1;
     } else {
-      sample = rand() / (RAND_MAX + 1.0);
+      sample = (double) rand() / RAND_MAX;
       interval = -log(1 - sample) / total;
-      point = rand() * total;
+      point = ((double) rand() / RAND_MAX) * total;
 
-      printf("sample: %d - interval: %d - point: %d", sample, interval, point);
+      printf("sample: %f - interval: %f - point: %f\n", sample, interval, point);
 
       choice = 0;
       progress = 0.0;
@@ -97,10 +97,17 @@ evolve(int reactions_length,
         choice += 1;
       }
 
-      if (choice == -1 || now + interval > duration)
+      printf("progress: %f - choice: %d - now: %f - duration: %f\n", progress, choice, now, duration);
+
+      if ((choice == -1) || ((now + interval) > duration)) {
+        printf("completing: %d %d", choice == -1, (now + interval) > duration);
         break;
+      }
 
       now += interval;
+
+      printf("new time: %f\n", now);
+
       time[step] = now;
       events[step] = choice;
 
@@ -112,6 +119,9 @@ evolve(int reactions_length,
       for (up = 0; up < update_length; up++) {
         update[up] = dependencies[dependencies_indexes[choice] + up];
       }
+
+      printf("update\n");
+      print_array(update, update_length);
     }
 
     step += 1;

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -7,7 +7,11 @@ int print_array(double * array, int length) {
   return 0;
 }
 
-evolve_result evolve(double ** stoichiometry, double * rates, double * state, double duration) {
+evolve_result
+evolve(double ** stoichiometry,
+       double * rates,
+       double * state,
+       double duration) {
   evolve_result result = {NULL, NULL, NULL};
   return result;
 }

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -9,7 +9,9 @@ print_array(double * array, int length) {
 }
 
 evolve_result
-evolve(double ** stoichiometry,
+evolve(int reactions_length,
+       int substrates_length,
+       double * stoichiometry,
        double * rates,
        double * state,
        double duration) {

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -33,12 +33,12 @@ print_long_array(long * array, int length) {
 
 static int INITIAL_LENGTH = 1000;
 
-int
-choose(int n, int k) {
+double
+choose(long n, long k) {
   double combinations = 1.0;
-  int i;
+  long i;
   for (i = 0; i < k; i++) {
-    combinations *= (n - i) / (i + 1);
+    combinations *= ((double) (n - i)) / (i + 1);
   }
   return combinations;
 }
@@ -46,13 +46,13 @@ choose(int n, int k) {
 evolve_result
 evolve(int reactions_length,
        int substrates_length,
-       double * stoichiometry,
+       long * stoichiometry,
        double * rates,
 
        long * reactants_lengths,
        long * reactants_indexes,
        long * reactants,
-       double * reactions,
+       long * reactions,
        
        long * dependencies_lengths,
        long * dependencies_indexes,
@@ -63,19 +63,19 @@ evolve(int reactions_length,
        long * actors,
 
        double duration,
-       double * state) {
+       long * state) {
 
   double * time = malloc((sizeof (double *)) * INITIAL_LENGTH);
   long * events = malloc((sizeof (long *)) * INITIAL_LENGTH);
-  double * outcome = malloc((sizeof (double *)) * substrates_length);
+  long * outcome = malloc((sizeof (long *)) * substrates_length);
 
   double * propensities = malloc((sizeof (double *)) * reactions_length);
   long * update = malloc((sizeof (long *)) * reactions_length);
   long update_length = reactions_length;
   long actors_length;
 
-  long reaction, reactant, species, index, actor;
-  double total, interval, sample, progress, point, adjustment, count;
+  long reaction, reactant, species, index, actor, count, adjustment;
+  double total, interval, sample, progress, point;
   
   int choice, step = 0, up = 0;
   double now = 0.0;

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -5,7 +5,7 @@
 #include "obsidian.h"
 
 // Initial length of event vectors
-static int INITIAL_LENGTH = 4000;
+static const int INITIAL_LENGTH = 4000;
 
 // Find the number of combinations of choosing k selections from n items
 double
@@ -121,9 +121,7 @@ evolve(MTState *random_state,
   // Copy the initial state that was supplied from outside to the working `outcome`
   // array we will use to actually apply the reactions and determine the next step's
   // state.
-  for (species = 0; species < substrates_count; species++) {
-    outcome[species] = state[species];
-  }
+  memcpy(outcome, state, (sizeof (long)) * substrates_count);
 
   // The `update` array will hold for each step which propensities need to be updated
   // for the next time step, based on the dependencies between reactions (sharing

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -1,4 +1,6 @@
+#include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "obsidian.h"
 
 int
@@ -8,13 +10,119 @@ print_array(double * array, int length) {
   return 0;
 }
 
+static int INITIAL_LENGTH = 1000;
+
+int
+choose(int n, int k) {
+  double combinations = 1.0;
+  int i;
+  for (i = 0; i < k; i++) {
+    combinations *= (n - i) / (i + 1);
+  }
+  return combinations;
+}
+
 evolve_result
 evolve(int reactions_length,
        int substrates_length,
        double * stoichiometry,
        double * rates,
-       double * state,
-       double duration) {
-  evolve_result result = {NULL, NULL, NULL};
+
+       int * reactants_lengths,
+       int * reactants_indexes,
+       int * reactants,
+       double * reactions,
+       
+       int * dependencies_lengths,
+       int * dependencies_indexes,
+       int * dependencies,
+
+       double duration,
+       double * state) {
+
+  double * time = malloc((sizeof (double *)) * INITIAL_LENGTH);
+  int * events = malloc((sizeof (int *)) * INITIAL_LENGTH);
+
+  double * propensities = malloc((sizeof (double *)) * reactions_length);
+  int * update = malloc((sizeof (int *)) * reactions_length);
+  int update_length = reactions_length;
+
+  int reaction, reactant, species, index;
+  double total, interval, sample, progress, point;
+  
+  int choice, step = 0, up = 0;
+  double now = 0.0;
+
+  for (reaction = 0; reaction < reactions_length; reaction++) {
+    update[reaction] = reaction;
+  }
+
+  while(now < duration) {
+    printf("step %i", step);
+
+    for (up = 0; up < update_length; up++) {
+      int reaction = update[up];
+      propensities[reaction] = rates[reaction];
+
+      for (reactant = 0; reactant < reactants_lengths[reaction]; reactant++) {
+        index = reactants_indexes[reaction] + reactant;
+        propensities[reaction] *= choose(state[reactants[index]], reactions[index]);
+      }
+    }
+
+    printf("propensities");
+    print_array(propensities, reactions_length);
+
+    total = 0.0;
+    for (reaction = 0; reaction < reactions_length; reaction++) {
+      total += propensities[reaction];
+    }
+
+    printf("total: %d\n", total);
+
+    if (total == 0) {
+      interval = 0.0;
+      choice = -1;
+    } else {
+      sample = rand() / (RAND_MAX + 1.0);
+      interval = -log(1 - sample) / total;
+      point = rand() * total;
+
+      printf("sample: %d - interval: %d - point: %d", sample, interval, point);
+
+      choice = 0;
+      progress = 0.0;
+      while(progress + propensities[choice] < point) {
+        progress += propensities[choice];
+        choice += 1;
+      }
+
+      if (choice == -1 || now + interval > duration)
+        break;
+
+      now += interval;
+      time[step] = now;
+      events[step] = choice;
+
+      for (species = 0; species < substrates_length; species++) {
+        state[species] += stoichiometry[choice * substrates_length + species];
+      }
+
+      update_length = dependencies_lengths[choice];
+      for (up = 0; up < update_length; up++) {
+        update[up] = dependencies[dependencies_indexes[choice] + up];
+      }
+    }
+
+    step += 1;
+  }
+
+  print_array(state, substrates_length);
+  
+  evolve_result result = {0, time, events, state};
+
+  free(propensities);
+  free(update);
+
   return result;
 }

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -124,11 +124,11 @@ evolve(MTState *random_state,
       update == NULL) {
     printf("allocating memory inside evolve failed: %d", errno);
 
-    if (time != NULL) free(time);
-    if (events != NULL) free(events);
-    if (outcome != NULL) free(outcome);
-    if (propensities != NULL) free(propensities);
-    if (update != NULL) free(update);
+    free(time);
+    free(events);
+    free(outcome);
+    free(propensities);
+    free(update);
 
     return failure;
   }
@@ -246,11 +246,11 @@ evolve(MTState *random_state,
         if (new_time == NULL) {
           printf("failed to allocate memory: %d", errno);
 
-          if (time != NULL) free(time);
-          if (events != NULL) free(events);
-          if (outcome != NULL) free(outcome);
-          if (propensities != NULL) free(propensities);
-          if (update != NULL) free(update);
+          free(time);
+          free(events);
+          free(outcome);
+          free(propensities);
+          free(update);
 
           return failure;
         }
@@ -263,11 +263,11 @@ evolve(MTState *random_state,
         if (new_events == NULL) {
           printf("failed to allocate memory: %d", errno);
 
-          if (time != NULL) free(time);
-          if (events != NULL) free(events);
-          if (outcome != NULL) free(outcome);
-          if (propensities != NULL) free(propensities);
-          if (update != NULL) free(update);
+          free(time);
+          free(events);
+          free(outcome);
+          free(propensities);
+          free(update);
 
           return failure;
         }

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -1,7 +1,8 @@
 #include <stdio.h>
 #include "obsidian.h"
 
-int print_array(double * array, int length) {
+int
+print_array(double * array, int length) {
   for (int index = 0; index < length; index++)
     printf("array[%d] = %f\n", index, array[index]);
   return 0;

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -58,9 +58,9 @@ evolve(int reactions_length,
        long * dependencies_indexes,
        long * dependencies,
 
-       long * actors_lengths,
-       long * actors_indexes,
-       long * actors,
+       long * involved_lengths,
+       long * involved_indexes,
+       long * involved,
 
        double duration,
        long * state) {
@@ -73,9 +73,9 @@ evolve(int reactions_length,
   double * propensities = malloc((sizeof (double *)) * reactions_length);
   long * update = malloc((sizeof (long *)) * reactions_length);
   long update_length = reactions_length;
-  long actors_length;
+  long involved_length;
 
-  long reaction, reactant, species, index, actor, count, adjustment;
+  long reaction, reactant, species, index, involve, count, adjustment;
   double total, interval, sample, progress, point;
   
   int choice, step = 0, up = 0;
@@ -131,11 +131,11 @@ evolve(int reactions_length,
       time[step] = now;
       events[step] = choice;
 
-      actors_length = actors_lengths[choice];
-      for (actor = 0; actor < actors_length; actor++) {
-        index = actors_indexes[choice] + actor;
-        adjustment = stoichiometry[choice * substrates_length + actors[index]];
-        outcome[actors[index]] += adjustment;
+      involved_length = involved_lengths[choice];
+      for (involve = 0; involve < involved_length; involve++) {
+        index = involved_indexes[choice] + involve;
+        adjustment = stoichiometry[choice * substrates_length + involved[index]];
+        outcome[involved[index]] += adjustment;
       }
 
       update_length = dependencies_lengths[choice];

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -6,19 +6,19 @@ struct evolve_result {
   int steps;
   double * time;
   long * events;
-  double * state;
+  long * state;
 };
 
 evolve_result
 evolve(int reactions_length,
        int substrates_length,
-       double * stoichiometry,
+       long * stoichiometry,
        double * rates,
 
        long * reactants_lengths,
        long * reactants_indexes,
        long * reactants,
-       double * reactions,
+       long * reactions,
        
        long * dependencies_lengths,
        long * dependencies_indexes,
@@ -29,4 +29,4 @@ evolve(int reactions_length,
        long * actors,
 
        double duration,
-       double * state);
+       long * state);

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -1,3 +1,5 @@
+#include "mersenne.h"
+
 // The structure for holding the result of the Gillespie algorithm
 typedef struct evolve_result evolve_result;
 struct evolve_result {
@@ -9,7 +11,9 @@ struct evolve_result {
 
 // Invoke the system with all the required information to run for the given duration
 evolve_result
-evolve(int reactions_count,
+evolve(MTState * random_state,
+
+       int reactions_count,
        int substrates_count,
        long * stoichiometry,
        double * rates,

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -6,7 +6,7 @@ struct evolve_result {
   int steps;
   double * time;
   long * events;
-  long * state;
+  long * outcome;
 };
 
 evolve_result

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -24,9 +24,9 @@ evolve(int reactions_length,
        long * dependencies_indexes,
        long * dependencies,
 
-       long * actors_lengths,
-       long * actors_indexes,
-       long * actors,
+       long * involved_lengths,
+       long * involved_indexes,
+       long * involved,
 
        double duration,
        long * state);

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -24,5 +24,9 @@ evolve(int reactions_length,
        long * dependencies_indexes,
        long * dependencies,
 
+       long * actors_lengths,
+       long * actors_indexes,
+       long * actors,
+
        double duration,
        double * state);

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -1,10 +1,11 @@
 int print_array(double * array, int length);
+int print_long_array(long * array, int length);
 
 typedef struct evolve_result evolve_result;
 struct evolve_result {
   int steps;
   double * time;
-  int * events;
+  long * events;
   double * state;
 };
 
@@ -14,14 +15,14 @@ evolve(int reactions_length,
        double * stoichiometry,
        double * rates,
 
-       int * reactants_lengths,
-       int * reactants_indexes,
-       int * reactants,
+       long * reactants_lengths,
+       long * reactants_indexes,
+       long * reactants,
        double * reactions,
        
-       int * dependencies_lengths,
-       int * dependencies_indexes,
-       int * dependencies,
+       long * dependencies_lengths,
+       long * dependencies_indexes,
+       long * dependencies,
 
        double duration,
        double * state);

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -7,4 +7,8 @@ struct evolve_result {
   int * events;
 };
 
-evolve_result evolve(double ** stoichiometry, double * rates, double * state, double duration);
+evolve_result
+evolve(double ** stoichiometry,
+       double * rates,
+       double * state,
+       double duration);

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -1,39 +1,44 @@
+#ifndef OBSIDIAN_H
+#define OBSIDIAN_H
+
 #include "mersenne.h"
 
 // The structure for holding the result of the Gillespie algorithm
 typedef struct evolve_result evolve_result;
 struct evolve_result {
   int steps;
-  double * time;
-  long * events;
-  long * outcome;
+  double *time;
+  long *events;
+  long *outcome;
 };
 
 // Invoke the system with all the required information to run for the given duration
 evolve_result
-evolve(MTState * random_state,
+evolve(MTState *random_state,
 
        int reactions_count,
        int substrates_count,
-       long * stoichiometry,
-       double * rates,
+       long *stoichiometry,
+       double *rates,
 
-       long * reactants_lengths,
-       long * reactants_indexes,
-       long * reactants,
-       long * reactions,
+       long *reactants_lengths,
+       long *reactants_indexes,
+       long *reactants,
+       long *reactions,
        
-       long * dependencies_lengths,
-       long * dependencies_indexes,
-       long * dependencies,
+       long *dependencies_lengths,
+       long *dependencies_indexes,
+       long *dependencies,
 
-       long * substrates_lengths,
-       long * substrates_indexes,
-       long * substrates,
+       long *substrates_lengths,
+       long *substrates_indexes,
+       long *substrates,
 
        double duration,
-       long * state);
+       long *state);
 
 // Supporting print utilities
-int print_array(double * array, int length);
-int print_long_array(long * array, int length);
+int print_array(double *array, int length);
+int print_long_array(long *array, int length);
+
+#endif

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -8,7 +8,9 @@ struct evolve_result {
 };
 
 evolve_result
-evolve(double ** stoichiometry,
+evolve(int reactions_length,
+       int substrates_length,
+       double * stoichiometry,
        double * rates,
        double * state,
        double duration);

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -2,9 +2,10 @@ int print_array(double * array, int length);
 
 typedef struct evolve_result evolve_result;
 struct evolve_result {
+  int steps;
   double * time;
-  double ** counts;
   int * events;
+  double * state;
 };
 
 evolve_result
@@ -12,5 +13,15 @@ evolve(int reactions_length,
        int substrates_length,
        double * stoichiometry,
        double * rates,
-       double * state,
-       double duration);
+
+       int * reactants_lengths,
+       int * reactants_indexes,
+       int * reactants,
+       double * reactions,
+       
+       int * dependencies_lengths,
+       int * dependencies_indexes,
+       int * dependencies,
+
+       double duration,
+       double * state);

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -1,0 +1,10 @@
+int print_array(double * array, int length);
+
+typedef struct evolve_result evolve_result;
+struct evolve_result {
+  double * time;
+  double ** counts;
+  int * events;
+};
+
+evolve_result evolve(double ** stoichiometry, double * rates, double * state, double duration);

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -9,8 +9,8 @@ struct evolve_result {
 
 // Invoke the system with all the required information to run for the given duration
 evolve_result
-evolve(int reactions_length,
-       int substrates_length,
+evolve(int reactions_count,
+       int substrates_count,
        long * stoichiometry,
        double * rates,
 
@@ -23,9 +23,9 @@ evolve(int reactions_length,
        long * dependencies_indexes,
        long * dependencies,
 
-       long * involved_lengths,
-       long * involved_indexes,
-       long * involved,
+       long * substrates_lengths,
+       long * substrates_indexes,
+       long * substrates,
 
        double duration,
        long * state);

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -1,6 +1,4 @@
-int print_array(double * array, int length);
-int print_long_array(long * array, int length);
-
+// The structure for holding the result of the Gillespie algorithm
 typedef struct evolve_result evolve_result;
 struct evolve_result {
   int steps;
@@ -9,6 +7,7 @@ struct evolve_result {
   long * outcome;
 };
 
+// Invoke the system with all the required information to run for the given duration
 evolve_result
 evolve(int reactions_length,
        int substrates_length,
@@ -30,3 +29,7 @@ evolve(int reactions_length,
 
        double duration,
        long * state);
+
+// Supporting print utilities
+int print_array(double * array, int length);
+int print_long_array(long * array, int length);

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -2,136 +2,136 @@
 #include <numpy/arrayobject.h>
 #include "obsidian.h"
 
-/* static PyObject *ErrorObject; */
+static PyObject *ErrorObject;
 
-/* typedef struct { */
-/*   PyObject_HEAD */
-/*   PyObject *x_attr; */
-/* } ObsidianObject; */
+typedef struct {
+  PyObject_HEAD
+  PyObject *x_attr;
+} ObsidianObject;
 
-/* static PyTypeObject Obsidian_Type; */
+static PyTypeObject Obsidian_Type;
 
-/* #define ObsidianObject_Check(v)      (Py_TYPE(v) == &Obsidian_Type) */
+#define ObsidianObject_Check(v)      (Py_TYPE(v) == &Obsidian_Type)
 
-/* static ObsidianObject * */
-/* newObsidianObject(PyObject *arg) */
-/* { */
-/*   ObsidianObject *self; */
-/*   self = PyObject_New(ObsidianObject, &Obsidian_Type); */
+static ObsidianObject *
+newObsidianObject(PyObject *arg)
+{
+  ObsidianObject *self;
+  self = PyObject_New(ObsidianObject, &Obsidian_Type);
 
-/*   if (self == NULL) */
-/*     return NULL; */
+  if (self == NULL)
+    return NULL;
 
-/*   self->x_attr = NULL; */
-/*   return self; */
-/* } */
+  self->x_attr = NULL;
+  return self;
+}
 
-/* static void */
-/* Obsidian_dealloc(ObsidianObject *self) */
-/* { */
-/*   Py_XDECREF(self->x_attr); */
-/*   PyObject_Del(self); */
-/* } */
+static void
+Obsidian_dealloc(ObsidianObject *self)
+{
+  Py_XDECREF(self->x_attr);
+  PyObject_Del(self);
+}
 
-/* static PyObject * */
-/* Obsidian_demo(ObsidianObject *self, PyObject *args) */
-/* { */
-/*   if (!PyArg_ParseTuple(args, ":demo")) */
-/*     return NULL; */
+static PyObject *
+Obsidian_demo(ObsidianObject *self, PyObject *args)
+{
+  if (!PyArg_ParseTuple(args, ":demo"))
+    return NULL;
 
-/*   Py_INCREF(Py_None); */
-/*   return Py_None; */
-/* } */
+  Py_INCREF(Py_None);
+  return Py_None;
+}
 
-/* static PyMethodDef Obsidian_methods[] = { */
-/*   {"demo", (PyCFunction) Obsidian_demo,  METH_VARARGS, PyDoc_STR("demo() -> None")}, */
-/*   {NULL, NULL}           /\* sentinel *\/ */
-/* }; */
+static PyMethodDef Obsidian_methods[] = {
+  {"demo", (PyCFunction) Obsidian_demo,  METH_VARARGS, PyDoc_STR("demo() -> None")},
+  {NULL, NULL}           /* sentinel */
+};
 
-/* static PyObject * */
-/* Obsidian_getattro(ObsidianObject *self, PyObject *name) */
-/* { */
-/*   if (self->x_attr != NULL) { */
-/*     PyObject *v = PyDict_GetItem(self->x_attr, name); */
+static PyObject *
+Obsidian_getattro(ObsidianObject *self, PyObject *name)
+{
+  if (self->x_attr != NULL) {
+    PyObject *v = PyDict_GetItem(self->x_attr, name);
 
-/*     if (v != NULL) { */
-/*       Py_INCREF(v); */
-/*       return v; */
-/*     } */
-/*   } */
+    if (v != NULL) {
+      Py_INCREF(v);
+      return v;
+    }
+  }
 
-/*   return PyObject_GenericGetAttr((PyObject *)self, name); */
-/* } */
+  return PyObject_GenericGetAttr((PyObject *)self, name);
+}
 
-/* static int */
-/* Obsidian_setattr(ObsidianObject *self, const char *name, PyObject *v) */
-/* { */
-/*   if (self->x_attr == NULL) { */
-/*     self->x_attr = PyDict_New(); */
+static int
+Obsidian_setattr(ObsidianObject *self, const char *name, PyObject *v)
+{
+  if (self->x_attr == NULL) {
+    self->x_attr = PyDict_New();
 
-/*     if (self->x_attr == NULL) */
-/*       return -1; */
-/*   } */
-/*   if (v == NULL) { */
-/*     int rv = PyDict_DelItemString(self->x_attr, name); */
+    if (self->x_attr == NULL)
+      return -1;
+  }
+  if (v == NULL) {
+    int rv = PyDict_DelItemString(self->x_attr, name);
 
-/*     if (rv < 0) */
-/*       PyErr_SetString(PyExc_AttributeError, */
-/*                       "delete non-existing Obsidian attribute"); */
-/*     return rv; */
-/*   } */
-/*   else */
-/*     return PyDict_SetItemString(self->x_attr, name, v); */
-/* } */
+    if (rv < 0)
+      PyErr_SetString(PyExc_AttributeError,
+                      "delete non-existing Obsidian attribute");
+    return rv;
+  }
+  else
+    return PyDict_SetItemString(self->x_attr, name, v);
+}
 
-/* static PyTypeObject Obsidian_Type = { */
-/*   /\* The ob_type field must be initialized in the module init function */
-/*    * to be portable to Windows without using C++. *\/ */
-/*   PyVarObject_HEAD_INIT(NULL, 0) */
-/*   "xxmodule.Obsidian",              /\*tp_name*\/ */
-/*   sizeof(ObsidianObject),           /\*tp_basicsize*\/ */
-/*   0,                                /\*tp_itemsize*\/ */
-/*   /\* methods *\/ */
-/*   (destructor) Obsidian_dealloc,    /\*tp_dealloc*\/ */
-/*   0,                                /\*tp_print*\/ */
-/*   (getattrfunc) 0,                  /\*tp_getattr*\/ */
-/*   (setattrfunc) Obsidian_setattr,   /\*tp_setattr*\/ */
-/*   0,                                /\*tp_reserved*\/ */
-/*   0,                                /\*tp_repr*\/ */
-/*   0,                                /\*tp_as_number*\/ */
-/*   0,                                /\*tp_as_sequence*\/ */
-/*   0,                                /\*tp_as_mapping*\/ */
-/*   0,                                /\*tp_hash*\/ */
-/*   0,                                /\*tp_call*\/ */
-/*   0,                                /\*tp_str*\/ */
-/*   (getattrofunc) Obsidian_getattro, /\*tp_getattro*\/ */
-/*   0,                                /\*tp_setattro*\/ */
-/*   0,                                /\*tp_as_buffer*\/ */
-/*   Py_TPFLAGS_DEFAULT,               /\*tp_flags*\/ */
-/*   0,                                /\*tp_doc*\/ */
-/*   0,                                /\*tp_traverse*\/ */
-/*   0,                                /\*tp_clear*\/ */
-/*   0,                                /\*tp_richcompare*\/ */
-/*   0,                                /\*tp_weaklistoffset*\/ */
-/*   0,                                /\*tp_iter*\/ */
-/*   0,                                /\*tp_iternext*\/ */
-/*   Obsidian_methods,                 /\*tp_methods*\/ */
-/*   0,                                /\*tp_members*\/ */
-/*   0,                                /\*tp_getset*\/ */
-/*   0,                                /\*tp_base*\/ */
-/*   0,                                /\*tp_dict*\/ */
-/*   0,                                /\*tp_descr_get*\/ */
-/*   0,                                /\*tp_descr_set*\/ */
-/*   0,                                /\*tp_dictoffset*\/ */
-/*   0,                                /\*tp_init*\/ */
-/*   0,                                /\*tp_alloc*\/ */
-/*   0,                                /\*tp_new*\/ */
-/*   0,                                /\*tp_free*\/ */
-/*   0,                                /\*tp_is_gc*\/ */
-/* }; */
+static PyTypeObject Obsidian_Type = {
+  /* The ob_type field must be initialized in the module init function
+   * to be portable to Windows without using C++. */
+  PyVarObject_HEAD_INIT(NULL, 0)
+  "xxmodule.Obsidian",              /*tp_name*/
+  sizeof(ObsidianObject),           /*tp_basicsize*/
+  0,                                /*tp_itemsize*/
+  /* methods */
+  (destructor) Obsidian_dealloc,    /*tp_dealloc*/
+  0,                                /*tp_print*/
+  (getattrfunc) 0,                  /*tp_getattr*/
+  (setattrfunc) Obsidian_setattr,   /*tp_setattr*/
+  0,                                /*tp_reserved*/
+  0,                                /*tp_repr*/
+  0,                                /*tp_as_number*/
+  0,                                /*tp_as_sequence*/
+  0,                                /*tp_as_mapping*/
+  0,                                /*tp_hash*/
+  0,                                /*tp_call*/
+  0,                                /*tp_str*/
+  (getattrofunc) Obsidian_getattro, /*tp_getattro*/
+  0,                                /*tp_setattro*/
+  0,                                /*tp_as_buffer*/
+  Py_TPFLAGS_DEFAULT,               /*tp_flags*/
+  0,                                /*tp_doc*/
+  0,                                /*tp_traverse*/
+  0,                                /*tp_clear*/
+  0,                                /*tp_richcompare*/
+  0,                                /*tp_weaklistoffset*/
+  0,                                /*tp_iter*/
+  0,                                /*tp_iternext*/
+  Obsidian_methods,                 /*tp_methods*/
+  0,                                /*tp_members*/
+  0,                                /*tp_getset*/
+  0,                                /*tp_base*/
+  0,                                /*tp_dict*/
+  0,                                /*tp_descr_get*/
+  0,                                /*tp_descr_set*/
+  0,                                /*tp_dictoffset*/
+  0,                                /*tp_init*/
+  0,                                /*tp_alloc*/
+  0,                                /*tp_new*/
+  0,                                /*tp_free*/
+  0,                                /*tp_is_gc*/
+};
 
 
-
+// https://dfm.io/posts/python-c-extensions/
 
 static PyObject * _print_array(PyObject * self, PyObject * args) {
   PyObject *float_list;

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -14,7 +14,7 @@
 
 // Converts an arbitrary PyObject * into another PyObject * that represents a numpy array.
 // The reference to this array is transferred to the caller, who is responsible for decrementing
-// the reference once it is finished with it.
+// the reference once they are finished with it.
 static PyObject *
 array_for(PyObject * array_obj, int npy_type) {
   PyObject * array = PyArray_FROM_OTF(array_obj, npy_type, NPY_ARRAY_IN_ARRAY);
@@ -27,7 +27,7 @@ array_for(PyObject * array_obj, int npy_type) {
   return array;
 }
 
-// The definition of the data fields for an Obsidian object as a C struct.
+// The definition of the data fields for an Obsidian object as a C struct
 typedef struct {
   PyObject_HEAD
   PyObject * x_attr;
@@ -50,12 +50,12 @@ typedef struct {
   long * involved;
 } ObsidianObject;
 
-// Declaring a new python type for Obsidian.
+// Declaring a new python type for Obsidian
 static PyTypeObject Obsidian_Type;
 #define ObsidianObject_Check(v) (Py_TYPE(v) == &Obsidian_Type)
 
 // Accept all the information needed to construct a new Obsidian object
-// and return a reference to it.
+// and return a reference to it
 static ObsidianObject *
 newObsidianObject(int reactions_length,
                   int substrates_length,
@@ -103,7 +103,7 @@ newObsidianObject(int reactions_length,
   return self;
 }
 
-// Provide a means for deallocating the Obsidian object.
+// Provide a means for deallocating the Obsidian object
 static void
 Obsidian_dealloc(ObsidianObject *self)
 {
@@ -111,7 +111,7 @@ Obsidian_dealloc(ObsidianObject *self)
   PyObject_Del(self);
 }
 
-// A simple demo function that prints the reaction rates to stdout.
+// A simple demo function that prints the reaction rates to stdout
 static PyObject *
 Obsidian_demo(ObsidianObject *self, PyObject *args)
 {
@@ -124,7 +124,7 @@ Obsidian_demo(ObsidianObject *self, PyObject *args)
   return Py_None;
 }
 
-// Obtain the number of reactions for this system.
+// Obtain the number of reactions for this system
 static PyObject *
 Obsidian_reactions_length(ObsidianObject *self, PyObject *args)
 {
@@ -134,7 +134,7 @@ Obsidian_reactions_length(ObsidianObject *self, PyObject *args)
   return Py_BuildValue("i", self->reactions_length);
 }
 
-// Find the number of substrates this system operates upon.
+// Find the number of substrates this system operates upon
 static PyObject *
 Obsidian_substrates_length(ObsidianObject *self, PyObject *args)
 {
@@ -150,19 +150,19 @@ Obsidian_substrates_length(ObsidianObject *self, PyObject *args)
 static PyObject *
 Obsidian_evolve(ObsidianObject *self, PyObject *args)
 {
-  // The variables that will be extracted from python.
+  // The variables that will be extracted from python
   double duration;
   PyObject * state_obj;
 
-  // Obtain the arguments as the references declared above.
+  // Obtain the arguments as the references declared above
   if (!PyArg_ParseTuple(args, "dO", &duration, &state_obj))
     return NULL;
 
-  // Pull the long * data out of the state numpy array.
+  // Pull the long * data out of the state numpy array
   PyObject * state_array = array_for(state_obj, NPY_INT64);
   long * state = (long *) PyArray_DATA(state_array);
 
-  // Invoke the actual algorithm with all of the required information.
+  // Invoke the actual algorithm with all of the required information
   evolve_result result = evolve(self->reactions_length,
                                 self->substrates_length,
                                 self->stoichiometry,
@@ -180,22 +180,22 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
                                 duration,
                                 state);
   
-  // Declare containers for the results.
+  // Declare containers for the results
   long steps[1];
   steps[0] = result.steps;
 
   long substrates[1];
   substrates[0] = self->substrates_length;
 
-  // Create new python numpy arrays from the raw C results.
+  // Create new python numpy arrays from the raw C results
   PyObject * time_obj = PyArray_SimpleNewFromData(1, steps, NPY_DOUBLE, result.time);
   PyObject * events_obj = PyArray_SimpleNewFromData(1, steps, NPY_INT64, result.events);
   PyObject * outcome_obj = PyArray_SimpleNewFromData(1, substrates, NPY_INT64, result.outcome);
 
-  // Decrement the reference to the state array now that we are done with it.
+  // Decrement the reference to the state array now that we are done with it
   Py_XDECREF(state_array);
 
-  // Construct the return value that will be ultimately visible to python.
+  // Construct the return value that will be ultimately visible to python
   return Py_BuildValue("iOOO",
                        result.steps,
                        time_obj,
@@ -204,7 +204,7 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
 }
 
 // Declare the various methods that an Obsidian object will have and align them with their
-// respective C definitions.
+// respective C definitions
 static PyMethodDef Obsidian_methods[] = {
   {"demo", (PyCFunction) Obsidian_demo,  METH_VARARGS, PyDoc_STR("demo() -> None")},
   {"reactions_length", (PyCFunction) Obsidian_reactions_length,  METH_VARARGS, PyDoc_STR("number of reactions this system is capable of.")},
@@ -213,7 +213,7 @@ static PyMethodDef Obsidian_methods[] = {
   {NULL, NULL} // sentinel
 };
 
-// Provide a means for reading attributes from an Obsidian object.
+// Provide a means for reading attributes from an Obsidian object
 static PyObject *
 Obsidian_getattro(ObsidianObject *self, PyObject *name)
 {
@@ -229,7 +229,7 @@ Obsidian_getattro(ObsidianObject *self, PyObject *name)
   return PyObject_GenericGetAttr((PyObject *)self, name);
 }
 
-// Provide a means for setting attributes in an Obsidian object.
+// Provide a means for setting attributes in an Obsidian object
 static int
 Obsidian_setattr(ObsidianObject *self, const char *name, PyObject *v)
 {
@@ -251,7 +251,7 @@ Obsidian_setattr(ObsidianObject *self, const char *name, PyObject *v)
     return PyDict_SetItemString(self->x_attr, name, v);
 }
 
-// Create the object table for an Obsidian object as defined by python internals.
+// Create the object table for an Obsidian object as defined by python internals
 static PyTypeObject Obsidian_Type = {
   PyVarObject_HEAD_INIT(NULL, 0)
   "obsidianmodule.Obsidian",        // tp_name
@@ -296,7 +296,7 @@ static PyTypeObject Obsidian_Type = {
   0,                                // tp_is_gc
 };
 
-// Print a python array of floats.
+// Print a python array of floats
 static PyObject *
 _print_array(PyObject * self, PyObject * args) {
   PyObject *float_list;
@@ -330,6 +330,7 @@ _print_array(PyObject * self, PyObject * args) {
   return Py_BuildValue("i", value);
 }
 
+// Accept the necessary information to construct the Obsidian object.
 static PyObject *
 _invoke_obsidian(PyObject * self, PyObject * args) {
   ObsidianObject * obsidian;
@@ -368,13 +369,13 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
                         &involved_obj))
     return NULL;
 
-  // import the stoichiometric_matrix as a 2d numpy array
+  // Import the 2d stoichiometric_matrix as a 1d numpy array
   PyObject * stoichiometry_array = array_for(stoichiometry_obj, NPY_INT64);
   int reactions_length = (int) PyArray_DIM(stoichiometry_array, 0);
   int substrates_length = (int) PyArray_DIM(stoichiometry_array, 1);
   long * stoichiometry = (long *) PyArray_DATA(stoichiometry_array);
 
-  // import the rates as a 1d numpy array
+  // Import the rates for each reaction
   PyObject * rates_array = array_for(rates_obj, NPY_DOUBLE);
   double * rates = (double *) PyArray_DATA(rates_array);
 
@@ -401,7 +402,7 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
   PyObject * involved_array = array_for(involved_obj, NPY_INT64);
   long * involved = (long *) PyArray_DATA(involved_array);
 
-  // create the obsidian object
+  // Create the obsidian object
   obsidian = newObsidianObject(reactions_length,
                                substrates_length,
                                stoichiometry,
@@ -424,6 +425,7 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
     return NULL;
   }
 
+  // Clean up all the PyObject * references
   Py_XDECREF(reactants_lengths_array);
   Py_XDECREF(reactants_indexes_array);
   Py_XDECREF(reactants_array);
@@ -437,20 +439,24 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
   Py_XDECREF(involved_indexes_array);
   Py_XDECREF(involved_array);
 
+  // Return the Obsidian object as a PyObject *
   return (PyObject *) obsidian;
 }
 
+// Declare the methods that the Obsidian module will have (as opposed to the Obsidian object)
 static PyMethodDef ObsidianMethods[] = {
   {"print_array", _print_array, METH_VARARGS, "print array of floats"},
   {"obsidian", _invoke_obsidian, METH_VARARGS, "create new obsidian object"},
   {NULL, NULL, 0, NULL}
 };
 
+// Initialize the Obsidian module within the python runtime
 PyMODINIT_FUNC initobsidian(void) {
   (void) Py_InitModule("obsidian", ObsidianMethods);
   import_array();
 }
 
+// Perform fundamental initialization
 int main(int argc, char** argv) {
   Py_SetProgramName(argv[0]);
   Py_Initialize();

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -91,7 +91,12 @@ newObsidianObject(int random_seed,
 
   // set up mersenne twister state from the provided seed
   self->random_seed = random_seed;
+
   MTState *random_state = malloc(sizeof (MTState));
+  if (random_state == NULL) {
+    return NULL;
+  }
+
   seed(random_state, random_seed);
   self->random_state = random_state;
 
@@ -196,6 +201,11 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
                                 duration,
                                 state);
   
+  if (result.steps == -1) {
+    Py_XDECREF(state_array);
+    return NULL;
+  }
+
   // Declare containers for the results
   long steps[1];
   steps[0] = result.steps;

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -130,8 +130,10 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
   double duration;
   PyObject * state_obj;
 
-  if (!PyArg_ParseTuple(args, "fO", &duration, &state_obj))
+  if (!PyArg_ParseTuple(args, "dO", &duration, &state_obj))
     return NULL;
+
+  printf("duration !!!! %f\n", duration);
 
   double * state = double_data_for(state_obj);
   evolve_result result = evolve(self->reactions_length,

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -145,9 +145,9 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
   if (!PyArg_ParseTuple(args, "dO", &duration, &state_obj))
     return NULL;
 
-  /* printf("duration !!!! %f\n", duration); */
+  PyObject * state_array = array_for(state_obj, NPY_INT64);
+  long * state = (long *) PyArray_DATA(state_array);
 
-  long * state = long_data_for(state_obj);
   evolve_result result = evolve(self->reactions_length,
                                 self->substrates_length,
                                 self->stoichiometry,
@@ -165,15 +165,6 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
                                 duration,
                                 state);
   
-  /* printf("time: "); */
-  /* print_array(result.time, result.steps); */
-
-  /* printf("events: "); */
-  /* print_long_array(result.events, result.steps); */
-
-  /* printf("state: "); */
-  /* print_array(result.state, self->substrates_length); */
-
   long steps[1];
   steps[0] = result.steps;
 
@@ -182,11 +173,9 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
 
   PyObject * time_obj = PyArray_SimpleNewFromData(1, steps, NPY_DOUBLE, result.time);
   PyObject * events_obj = PyArray_SimpleNewFromData(1, steps, NPY_INT64, result.events);
-  PyObject * outcome_obj = PyArray_SimpleNewFromData(1, substrates, NPY_INT64, result.state);
+  PyObject * outcome_obj = PyArray_SimpleNewFromData(1, substrates, NPY_INT64, result.outcome);
 
-  /* Py_XDECREF(state_obj); */
-  /* free(result.time); */
-  /* free(result.events); */
+  Py_XDECREF(state_array);
 
   return Py_BuildValue("iOOO",
                        result.steps,
@@ -366,18 +355,28 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
   PyObject * rates_array = array_for(rates_obj, NPY_DOUBLE);
   double * rates = (double *) PyArray_DATA(rates_array);
 
-  long * reactants_lengths = long_data_for(reactants_lengths_obj);
-  long * reactants_indexes = long_data_for(reactants_indexes_obj);
-  long * reactants = long_data_for(reactants_obj);
-  long * reactions = long_data_for(reactions_obj);
+  PyObject * reactants_lengths_array = array_for(reactants_lengths_obj, NPY_INT64);
+  long * reactants_lengths = (long *) PyArray_DATA(reactants_lengths_array);
+  PyObject * reactants_indexes_array = array_for(reactants_indexes_obj, NPY_INT64);
+  long * reactants_indexes = (long *) PyArray_DATA(reactants_indexes_array);
+  PyObject * reactants_array = array_for(reactants_obj, NPY_INT64);
+  long * reactants = (long *) PyArray_DATA(reactants_array);
+  PyObject * reactions_array = array_for(reactions_obj, NPY_INT64);
+  long * reactions = (long *) PyArray_DATA(reactions_array);
 
-  long * dependencies_lengths = long_data_for(dependencies_lengths_obj);
-  long * dependencies_indexes = long_data_for(dependencies_indexes_obj);
-  long * dependencies = long_data_for(dependencies_obj);
+  PyObject * dependencies_lengths_array = array_for(dependencies_lengths_obj, NPY_INT64);
+  long * dependencies_lengths = (long *) PyArray_DATA(dependencies_lengths_array);
+  PyObject * dependencies_indexes_array = array_for(dependencies_indexes_obj, NPY_INT64);
+  long * dependencies_indexes = (long *) PyArray_DATA(dependencies_indexes_array);
+  PyObject * dependencies_array = array_for(dependencies_obj, NPY_INT64);
+  long * dependencies = (long *) PyArray_DATA(dependencies_array);
 
-  long * actors_lengths = long_data_for(actors_lengths_obj);
-  long * actors_indexes = long_data_for(actors_indexes_obj);
-  long * actors = long_data_for(actors_obj);
+  PyObject * actors_lengths_array = array_for(actors_lengths_obj, NPY_INT64);
+  long * actors_lengths = (long *) PyArray_DATA(actors_lengths_array);
+  PyObject * actors_indexes_array = array_for(actors_indexes_obj, NPY_INT64);
+  long * actors_indexes = (long *) PyArray_DATA(actors_indexes_array);
+  PyObject * actors_array = array_for(actors_obj, NPY_INT64);
+  long * actors = (long *) PyArray_DATA(actors_array);
 
   // create the obsidian object
   obsidian = newObsidianObject(reactions_length,
@@ -401,6 +400,19 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
   if (obsidian == NULL) {
     return NULL;
   }
+
+  Py_XDECREF(reactants_lengths_array);
+  Py_XDECREF(reactants_indexes_array);
+  Py_XDECREF(reactants_array);
+  Py_XDECREF(reactions_array);
+
+  Py_XDECREF(dependencies_lengths_array);
+  Py_XDECREF(dependencies_indexes_array);
+  Py_XDECREF(dependencies_array);
+
+  Py_XDECREF(actors_lengths_array);
+  Py_XDECREF(actors_indexes_array);
+  Py_XDECREF(actors_array);
 
   return (PyObject *) obsidian;
 }

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -43,9 +43,9 @@ typedef struct {
   long * dependencies_indexes;
   long * dependencies;
 
-  long * actors_lengths;
-  long * actors_indexes;
-  long * actors;
+  long * involved_lengths;
+  long * involved_indexes;
+  long * involved;
 } ObsidianObject;
 
 static PyTypeObject Obsidian_Type;
@@ -67,9 +67,9 @@ newObsidianObject(int reactions_length,
                   long * dependencies_indexes,
                   long * dependencies,
 
-                  long * actors_lengths,
-                  long * actors_indexes,
-                  long * actors)
+                  long * involved_lengths,
+                  long * involved_indexes,
+                  long * involved)
 {
   ObsidianObject * self;
   self = PyObject_New(ObsidianObject, &Obsidian_Type);
@@ -92,9 +92,9 @@ newObsidianObject(int reactions_length,
   self->dependencies_indexes = dependencies_indexes;
   self->dependencies = dependencies;
 
-  self->actors_lengths = actors_lengths;
-  self->actors_indexes = actors_indexes;
-  self->actors = actors;
+  self->involved_lengths = involved_lengths;
+  self->involved_indexes = involved_indexes;
+  self->involved = involved;
 
   return self;
 }
@@ -159,9 +159,9 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
                                 self->dependencies_lengths,
                                 self->dependencies_indexes,
                                 self->dependencies,
-                                self->actors_lengths,
-                                self->actors_indexes,
-                                self->actors,
+                                self->involved_lengths,
+                                self->involved_indexes,
+                                self->involved,
                                 duration,
                                 state);
   
@@ -322,9 +322,9 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
     * dependencies_indexes_obj,
     * dependencies_obj,
 
-    * actors_lengths_obj,
-    * actors_indexes_obj,
-    * actors_obj;
+    * involved_lengths_obj,
+    * involved_indexes_obj,
+    * involved_obj;
 
   if (!PyArg_ParseTuple(args,
                         "OOOOOOOOOOOO",
@@ -340,9 +340,9 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
                         &dependencies_indexes_obj,
                         &dependencies_obj,
 
-                        &actors_lengths_obj,
-                        &actors_indexes_obj,
-                        &actors_obj))
+                        &involved_lengths_obj,
+                        &involved_indexes_obj,
+                        &involved_obj))
     return NULL;
 
   // import the stoichiometric_matrix as a 2d numpy array
@@ -371,12 +371,12 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
   PyObject * dependencies_array = array_for(dependencies_obj, NPY_INT64);
   long * dependencies = (long *) PyArray_DATA(dependencies_array);
 
-  PyObject * actors_lengths_array = array_for(actors_lengths_obj, NPY_INT64);
-  long * actors_lengths = (long *) PyArray_DATA(actors_lengths_array);
-  PyObject * actors_indexes_array = array_for(actors_indexes_obj, NPY_INT64);
-  long * actors_indexes = (long *) PyArray_DATA(actors_indexes_array);
-  PyObject * actors_array = array_for(actors_obj, NPY_INT64);
-  long * actors = (long *) PyArray_DATA(actors_array);
+  PyObject * involved_lengths_array = array_for(involved_lengths_obj, NPY_INT64);
+  long * involved_lengths = (long *) PyArray_DATA(involved_lengths_array);
+  PyObject * involved_indexes_array = array_for(involved_indexes_obj, NPY_INT64);
+  long * involved_indexes = (long *) PyArray_DATA(involved_indexes_array);
+  PyObject * involved_array = array_for(involved_obj, NPY_INT64);
+  long * involved = (long *) PyArray_DATA(involved_array);
 
   // create the obsidian object
   obsidian = newObsidianObject(reactions_length,
@@ -393,9 +393,9 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
                                dependencies_indexes,
                                dependencies,
 
-                               actors_lengths,
-                               actors_indexes,
-                               actors);
+                               involved_lengths,
+                               involved_indexes,
+                               involved);
 
   if (obsidian == NULL) {
     return NULL;
@@ -410,9 +410,9 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
   Py_XDECREF(dependencies_indexes_array);
   Py_XDECREF(dependencies_array);
 
-  Py_XDECREF(actors_lengths_array);
-  Py_XDECREF(actors_indexes_array);
-  Py_XDECREF(actors_array);
+  Py_XDECREF(involved_lengths_array);
+  Py_XDECREF(involved_indexes_array);
+  Py_XDECREF(involved_array);
 
   return (PyObject *) obsidian;
 }

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -1,0 +1,44 @@
+#include <Python.h>
+
+int _print_array(double pr[], int length) {
+  for (int index = 0; index < length; index++)
+    printf("pr[%d] = %f\n", index, pr[index]);
+  return 0;
+}
+
+static PyObject * print_array(PyObject * self, PyObject * args) {
+  PyObject *float_list;
+  int pr_length;
+  double *pr;
+
+  if (!PyArg_ParseTuple(args, "O", &float_list))
+    return NULL;
+
+  pr_length = PyObject_Length(float_list);
+  if (pr_length < 0)
+    return NULL;
+
+  pr = (double *) malloc(sizeof(double *) * pr_length);
+  if (pr == NULL)
+    return NULL;
+
+  for (int index = 0; index < pr_length; index++) {
+    PyObject *item;
+    item = PyList_GetItem(float_list, index);
+    if (!PyFloat_Check(item))
+      pr[index] = 0.0;
+
+    pr[index] = PyFloat_AsDouble(item);
+  }
+
+  return Py_BuildValue("i", _print_array(pr, pr_length));
+}
+
+static PyMethodDef ObsidianMethods[] = {
+  {"print_array", print_array, METH_VARARGS, "print array of floats"},
+  {NULL, NULL, 0, NULL}
+};
+
+PyMODINIT_FUNC initobsidian(void) {
+  (void) Py_InitModule("obsidian", ObsidianMethods);
+}

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -41,6 +41,8 @@ Obsidian_demo(ObsidianObject *self, PyObject *args)
   if (!PyArg_ParseTuple(args, ":demo"))
     return NULL;
 
+  print_array(self->rates, self->rates_length);
+
   Py_INCREF(Py_None);
   return Py_None;
 }

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -17,8 +17,8 @@
 // array. The reference to this array is transferred to the caller, who is responsible
 // for decrementing the reference once they are finished with it.
 static PyObject *
-array_for(PyObject * array_obj, int npy_type) {
-  PyObject * array = PyArray_FROM_OTF(array_obj, npy_type, NPY_ARRAY_IN_ARRAY);
+array_for(PyObject *array_obj, int npy_type) {
+  PyObject *array = PyArray_FROM_OTF(array_obj, npy_type, NPY_ARRAY_IN_ARRAY);
 
   if (array == NULL) {
     Py_XDECREF(array);
@@ -31,28 +31,28 @@ array_for(PyObject * array_obj, int npy_type) {
 // The definition of the data fields for an Obsidian object as a C struct
 typedef struct {
   PyObject_HEAD
-  PyObject * x_attr;
+  PyObject *x_attr;
 
   int random_seed;
-  MTState * random_state;
+  MTState *random_state;
 
   int reactions_count;
   int substrates_count;
-  long * stoichiometry;
-  double * rates;
+  long *stoichiometry;
+  double *rates;
 
-  long * reactants_lengths;
-  long * reactants_indexes;
-  long * reactants;
-  long * reactions;
+  long *reactants_lengths;
+  long *reactants_indexes;
+  long *reactants;
+  long *reactions;
 
-  long * dependencies_lengths;
-  long * dependencies_indexes;
-  long * dependencies;
+  long *dependencies_lengths;
+  long *dependencies_indexes;
+  long *dependencies;
 
-  long * substrates_lengths;
-  long * substrates_indexes;
-  long * substrates;
+  long *substrates_lengths;
+  long *substrates_indexes;
+  long *substrates;
 } ObsidianObject;
 
 // Declaring a new python type for Obsidian
@@ -65,23 +65,23 @@ static ObsidianObject *
 newObsidianObject(int random_seed,
                   int reactions_count,
                   int substrates_count,
-                  long * stoichiometry,
-                  double * rates,
+                  long *stoichiometry,
+                  double *rates,
 
-                  long * reactants_lengths,
-                  long * reactants_indexes,
-                  long * reactants,
-                  long * reactions,
+                  long *reactants_lengths,
+                  long *reactants_indexes,
+                  long *reactants,
+                  long *reactions,
 
-                  long * dependencies_lengths,
-                  long * dependencies_indexes,
-                  long * dependencies,
+                  long *dependencies_lengths,
+                  long *dependencies_indexes,
+                  long *dependencies,
 
-                  long * substrates_lengths,
-                  long * substrates_indexes,
-                  long * substrates)
+                  long *substrates_lengths,
+                  long *substrates_indexes,
+                  long *substrates)
 {
-  ObsidianObject * self;
+  ObsidianObject *self;
   self = PyObject_New(ObsidianObject, &Obsidian_Type);
 
   if (self == NULL)
@@ -91,7 +91,7 @@ newObsidianObject(int random_seed,
 
   // set up mersenne twister state from the provided seed
   self->random_seed = random_seed;
-  MTState * random_state = malloc(sizeof (MTState));
+  MTState *random_state = malloc(sizeof (MTState));
   seed(random_state, random_seed);
   self->random_state = random_state;
 
@@ -167,15 +167,15 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
 {
   // The variables that will be extracted from python
   double duration;
-  PyObject * state_obj;
+  PyObject *state_obj;
 
   // Obtain the arguments as the references declared above
   if (!PyArg_ParseTuple(args, "dO", &duration, &state_obj))
     return NULL;
 
   // Pull the long * data out of the state numpy array
-  PyObject * state_array = array_for(state_obj, NPY_INT64);
-  long * state = (long *) PyArray_DATA(state_array);
+  PyObject *state_array = array_for(state_obj, NPY_INT64);
+  long *state = (long *) PyArray_DATA(state_array);
 
   // Invoke the actual algorithm with all of the required information
   evolve_result result = evolve(self->random_state,
@@ -204,9 +204,9 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
   substrates[0] = self->substrates_count;
 
   // Create new python numpy arrays from the raw C results
-  PyObject * time_obj = PyArray_SimpleNewFromData(1, steps, NPY_DOUBLE, result.time);
-  PyObject * events_obj = PyArray_SimpleNewFromData(1, steps, NPY_INT64, result.events);
-  PyObject * outcome_obj = PyArray_SimpleNewFromData(1, substrates, NPY_INT64, result.outcome);
+  PyObject *time_obj = PyArray_SimpleNewFromData(1, steps, NPY_DOUBLE, result.time);
+  PyObject *events_obj = PyArray_SimpleNewFromData(1, steps, NPY_INT64, result.events);
+  PyObject *outcome_obj = PyArray_SimpleNewFromData(1, substrates, NPY_INT64, result.outcome);
 
   // Decrement the reference to the state array now that we are done with it
   Py_XDECREF(state_array);
@@ -314,7 +314,7 @@ static PyTypeObject Obsidian_Type = {
 
 // Print a python array of floats
 static PyObject *
-_print_array(PyObject * self, PyObject * args) {
+_print_array(PyObject *self, PyObject *args) {
   PyObject *float_list;
   int pr_length;
   double *pr;
@@ -348,25 +348,25 @@ _print_array(PyObject * self, PyObject * args) {
 
 // Accept the necessary information to construct the Obsidian object.
 static PyObject *
-_invoke_obsidian(PyObject * self, PyObject * args) {
-  ObsidianObject * obsidian;
+_invoke_obsidian(PyObject *self, PyObject *args) {
+  ObsidianObject *obsidian;
 
   int random_seed;
-  PyObject * stoichiometry_obj,
-    * rates_obj,
+  PyObject *stoichiometry_obj,
+    *rates_obj,
 
-    * reactants_lengths_obj,
-    * reactants_indexes_obj,
-    * reactants_obj,
-    * reactions_obj,
+    *reactants_lengths_obj,
+    *reactants_indexes_obj,
+    *reactants_obj,
+    *reactions_obj,
 
-    * dependencies_lengths_obj,
-    * dependencies_indexes_obj,
-    * dependencies_obj,
+    *dependencies_lengths_obj,
+    *dependencies_indexes_obj,
+    *dependencies_obj,
 
-    * substrates_lengths_obj,
-    * substrates_indexes_obj,
-    * substrates_obj;
+    *substrates_lengths_obj,
+    *substrates_indexes_obj,
+    *substrates_obj;
 
   if (!PyArg_ParseTuple(args,
                         "iOOOOOOOOOOOO",
@@ -389,38 +389,38 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
     return NULL;
 
   // Import the 2d stoichiometric_matrix as a 1d numpy array
-  PyObject * stoichiometry_array = array_for(stoichiometry_obj, NPY_INT64);
+  PyObject *stoichiometry_array = array_for(stoichiometry_obj, NPY_INT64);
   int reactions_count = (int) PyArray_DIM(stoichiometry_array, 0);
   int substrates_count = (int) PyArray_DIM(stoichiometry_array, 1);
-  long * stoichiometry = (long *) PyArray_DATA(stoichiometry_array);
+  long *stoichiometry = (long *) PyArray_DATA(stoichiometry_array);
 
   // Import the rates for each reaction
-  PyObject * rates_array = array_for(rates_obj, NPY_DOUBLE);
-  double * rates = (double *) PyArray_DATA(rates_array);
+  PyObject *rates_array = array_for(rates_obj, NPY_DOUBLE);
+  double *rates = (double *) PyArray_DATA(rates_array);
 
   // Pull all the precalculated nested arrays
-  PyObject * reactants_lengths_array = array_for(reactants_lengths_obj, NPY_INT64);
-  long * reactants_lengths = (long *) PyArray_DATA(reactants_lengths_array);
-  PyObject * reactants_indexes_array = array_for(reactants_indexes_obj, NPY_INT64);
-  long * reactants_indexes = (long *) PyArray_DATA(reactants_indexes_array);
-  PyObject * reactants_array = array_for(reactants_obj, NPY_INT64);
-  long * reactants = (long *) PyArray_DATA(reactants_array);
-  PyObject * reactions_array = array_for(reactions_obj, NPY_INT64);
-  long * reactions = (long *) PyArray_DATA(reactions_array);
+  PyObject *reactants_lengths_array = array_for(reactants_lengths_obj, NPY_INT64);
+  long *reactants_lengths = (long *) PyArray_DATA(reactants_lengths_array);
+  PyObject *reactants_indexes_array = array_for(reactants_indexes_obj, NPY_INT64);
+  long *reactants_indexes = (long *) PyArray_DATA(reactants_indexes_array);
+  PyObject *reactants_array = array_for(reactants_obj, NPY_INT64);
+  long *reactants = (long *) PyArray_DATA(reactants_array);
+  PyObject *reactions_array = array_for(reactions_obj, NPY_INT64);
+  long *reactions = (long *) PyArray_DATA(reactions_array);
 
-  PyObject * dependencies_lengths_array = array_for(dependencies_lengths_obj, NPY_INT64);
-  long * dependencies_lengths = (long *) PyArray_DATA(dependencies_lengths_array);
-  PyObject * dependencies_indexes_array = array_for(dependencies_indexes_obj, NPY_INT64);
-  long * dependencies_indexes = (long *) PyArray_DATA(dependencies_indexes_array);
-  PyObject * dependencies_array = array_for(dependencies_obj, NPY_INT64);
-  long * dependencies = (long *) PyArray_DATA(dependencies_array);
+  PyObject *dependencies_lengths_array = array_for(dependencies_lengths_obj, NPY_INT64);
+  long *dependencies_lengths = (long *) PyArray_DATA(dependencies_lengths_array);
+  PyObject *dependencies_indexes_array = array_for(dependencies_indexes_obj, NPY_INT64);
+  long *dependencies_indexes = (long *) PyArray_DATA(dependencies_indexes_array);
+  PyObject *dependencies_array = array_for(dependencies_obj, NPY_INT64);
+  long *dependencies = (long *) PyArray_DATA(dependencies_array);
 
-  PyObject * substrates_lengths_array = array_for(substrates_lengths_obj, NPY_INT64);
-  long * substrates_lengths = (long *) PyArray_DATA(substrates_lengths_array);
-  PyObject * substrates_indexes_array = array_for(substrates_indexes_obj, NPY_INT64);
-  long * substrates_indexes = (long *) PyArray_DATA(substrates_indexes_array);
-  PyObject * substrates_array = array_for(substrates_obj, NPY_INT64);
-  long * substrates = (long *) PyArray_DATA(substrates_array);
+  PyObject *substrates_lengths_array = array_for(substrates_lengths_obj, NPY_INT64);
+  long *substrates_lengths = (long *) PyArray_DATA(substrates_lengths_array);
+  PyObject *substrates_indexes_array = array_for(substrates_indexes_obj, NPY_INT64);
+  long *substrates_indexes = (long *) PyArray_DATA(substrates_indexes_array);
+  PyObject *substrates_array = array_for(substrates_obj, NPY_INT64);
+  long *substrates = (long *) PyArray_DATA(substrates_array);
 
   // Create the obsidian object
   obsidian = newObsidianObject(random_seed,

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -133,12 +133,6 @@
 
 
 
-/* int _print_array(double pr[], int length) { */
-/*   for (int index = 0; index < length; index++) */
-/*     printf("pr[%d] = %f\n", index, pr[index]); */
-/*   return 0; */
-/* } */
-
 static PyObject * _print_array(PyObject * self, PyObject * args) {
   PyObject *float_list;
   int pr_length;

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -31,13 +31,13 @@ typedef struct {
   PyObject * x_attr;
   int reactions_length;
   int substrates_length;
-  double * stoichiometry;
+  long * stoichiometry;
   double * rates;
 
   long * reactants_lengths;
   long * reactants_indexes;
   long * reactants;
-  double * reactions;
+  long * reactions;
 
   long * dependencies_lengths;
   long * dependencies_indexes;
@@ -55,13 +55,13 @@ static PyTypeObject Obsidian_Type;
 static ObsidianObject *
 newObsidianObject(int reactions_length,
                   int substrates_length,
-                  double * stoichiometry,
+                  long * stoichiometry,
                   double * rates,
 
                   long * reactants_lengths,
                   long * reactants_indexes,
                   long * reactants,
-                  double * reactions,
+                  long * reactions,
 
                   long * dependencies_lengths,
                   long * dependencies_indexes,
@@ -147,7 +147,7 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
 
   /* printf("duration !!!! %f\n", duration); */
 
-  double * state = double_data_for(state_obj);
+  long * state = long_data_for(state_obj);
   evolve_result result = evolve(self->reactions_length,
                                 self->substrates_length,
                                 self->stoichiometry,
@@ -182,7 +182,7 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
 
   PyObject * time_obj = PyArray_SimpleNewFromData(1, steps, NPY_DOUBLE, result.time);
   PyObject * events_obj = PyArray_SimpleNewFromData(1, steps, NPY_INT64, result.events);
-  PyObject * outcome_obj = PyArray_SimpleNewFromData(1, substrates, NPY_DOUBLE, result.state);
+  PyObject * outcome_obj = PyArray_SimpleNewFromData(1, substrates, NPY_INT64, result.state);
 
   /* Py_XDECREF(state_obj); */
   /* free(result.time); */
@@ -357,10 +357,10 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
     return NULL;
 
   // import the stoichiometric_matrix as a 2d numpy array
-  PyObject * stoichiometry_array = array_for(stoichiometry_obj, NPY_DOUBLE);
+  PyObject * stoichiometry_array = array_for(stoichiometry_obj, NPY_INT64);
   int reactions_length = (int) PyArray_DIM(stoichiometry_array, 0);
   int substrates_length = (int) PyArray_DIM(stoichiometry_array, 1);
-  double * stoichiometry = (double *) PyArray_DATA(stoichiometry_array);
+  long * stoichiometry = (long *) PyArray_DATA(stoichiometry_array);
 
   // import the rates as a 1d numpy array
   PyObject * rates_array = array_for(rates_obj, NPY_DOUBLE);
@@ -369,7 +369,7 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
   long * reactants_lengths = long_data_for(reactants_lengths_obj);
   long * reactants_indexes = long_data_for(reactants_indexes_obj);
   long * reactants = long_data_for(reactants_obj);
-  double * reactions = double_data_for(reactions_obj);
+  long * reactions = long_data_for(reactions_obj);
 
   long * dependencies_lengths = long_data_for(dependencies_lengths_obj);
   long * dependencies_indexes = long_data_for(dependencies_indexes_obj);

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -1,12 +1,145 @@
 #include <Python.h>
+#include <numpy/arrayobject.h>
+#include "obsidian.h"
 
-int _print_array(double pr[], int length) {
-  for (int index = 0; index < length; index++)
-    printf("pr[%d] = %f\n", index, pr[index]);
-  return 0;
-}
+/* static PyObject *ErrorObject; */
 
-static PyObject * print_array(PyObject * self, PyObject * args) {
+/* typedef struct { */
+/*   PyObject_HEAD */
+/*   PyObject *x_attr; */
+/* } ObsidianObject; */
+
+/* static PyTypeObject Obsidian_Type; */
+
+/* #define ObsidianObject_Check(v)      (Py_TYPE(v) == &Obsidian_Type) */
+
+/* static ObsidianObject * */
+/* newObsidianObject(PyObject *arg) */
+/* { */
+/*   ObsidianObject *self; */
+/*   self = PyObject_New(ObsidianObject, &Obsidian_Type); */
+
+/*   if (self == NULL) */
+/*     return NULL; */
+
+/*   self->x_attr = NULL; */
+/*   return self; */
+/* } */
+
+/* static void */
+/* Obsidian_dealloc(ObsidianObject *self) */
+/* { */
+/*   Py_XDECREF(self->x_attr); */
+/*   PyObject_Del(self); */
+/* } */
+
+/* static PyObject * */
+/* Obsidian_demo(ObsidianObject *self, PyObject *args) */
+/* { */
+/*   if (!PyArg_ParseTuple(args, ":demo")) */
+/*     return NULL; */
+
+/*   Py_INCREF(Py_None); */
+/*   return Py_None; */
+/* } */
+
+/* static PyMethodDef Obsidian_methods[] = { */
+/*   {"demo", (PyCFunction) Obsidian_demo,  METH_VARARGS, PyDoc_STR("demo() -> None")}, */
+/*   {NULL, NULL}           /\* sentinel *\/ */
+/* }; */
+
+/* static PyObject * */
+/* Obsidian_getattro(ObsidianObject *self, PyObject *name) */
+/* { */
+/*   if (self->x_attr != NULL) { */
+/*     PyObject *v = PyDict_GetItem(self->x_attr, name); */
+
+/*     if (v != NULL) { */
+/*       Py_INCREF(v); */
+/*       return v; */
+/*     } */
+/*   } */
+
+/*   return PyObject_GenericGetAttr((PyObject *)self, name); */
+/* } */
+
+/* static int */
+/* Obsidian_setattr(ObsidianObject *self, const char *name, PyObject *v) */
+/* { */
+/*   if (self->x_attr == NULL) { */
+/*     self->x_attr = PyDict_New(); */
+
+/*     if (self->x_attr == NULL) */
+/*       return -1; */
+/*   } */
+/*   if (v == NULL) { */
+/*     int rv = PyDict_DelItemString(self->x_attr, name); */
+
+/*     if (rv < 0) */
+/*       PyErr_SetString(PyExc_AttributeError, */
+/*                       "delete non-existing Obsidian attribute"); */
+/*     return rv; */
+/*   } */
+/*   else */
+/*     return PyDict_SetItemString(self->x_attr, name, v); */
+/* } */
+
+/* static PyTypeObject Obsidian_Type = { */
+/*   /\* The ob_type field must be initialized in the module init function */
+/*    * to be portable to Windows without using C++. *\/ */
+/*   PyVarObject_HEAD_INIT(NULL, 0) */
+/*   "xxmodule.Obsidian",              /\*tp_name*\/ */
+/*   sizeof(ObsidianObject),           /\*tp_basicsize*\/ */
+/*   0,                                /\*tp_itemsize*\/ */
+/*   /\* methods *\/ */
+/*   (destructor) Obsidian_dealloc,    /\*tp_dealloc*\/ */
+/*   0,                                /\*tp_print*\/ */
+/*   (getattrfunc) 0,                  /\*tp_getattr*\/ */
+/*   (setattrfunc) Obsidian_setattr,   /\*tp_setattr*\/ */
+/*   0,                                /\*tp_reserved*\/ */
+/*   0,                                /\*tp_repr*\/ */
+/*   0,                                /\*tp_as_number*\/ */
+/*   0,                                /\*tp_as_sequence*\/ */
+/*   0,                                /\*tp_as_mapping*\/ */
+/*   0,                                /\*tp_hash*\/ */
+/*   0,                                /\*tp_call*\/ */
+/*   0,                                /\*tp_str*\/ */
+/*   (getattrofunc) Obsidian_getattro, /\*tp_getattro*\/ */
+/*   0,                                /\*tp_setattro*\/ */
+/*   0,                                /\*tp_as_buffer*\/ */
+/*   Py_TPFLAGS_DEFAULT,               /\*tp_flags*\/ */
+/*   0,                                /\*tp_doc*\/ */
+/*   0,                                /\*tp_traverse*\/ */
+/*   0,                                /\*tp_clear*\/ */
+/*   0,                                /\*tp_richcompare*\/ */
+/*   0,                                /\*tp_weaklistoffset*\/ */
+/*   0,                                /\*tp_iter*\/ */
+/*   0,                                /\*tp_iternext*\/ */
+/*   Obsidian_methods,                 /\*tp_methods*\/ */
+/*   0,                                /\*tp_members*\/ */
+/*   0,                                /\*tp_getset*\/ */
+/*   0,                                /\*tp_base*\/ */
+/*   0,                                /\*tp_dict*\/ */
+/*   0,                                /\*tp_descr_get*\/ */
+/*   0,                                /\*tp_descr_set*\/ */
+/*   0,                                /\*tp_dictoffset*\/ */
+/*   0,                                /\*tp_init*\/ */
+/*   0,                                /\*tp_alloc*\/ */
+/*   0,                                /\*tp_new*\/ */
+/*   0,                                /\*tp_free*\/ */
+/*   0,                                /\*tp_is_gc*\/ */
+/* }; */
+
+
+
+
+/* int _print_array(double pr[], int length) { */
+/*   for (int index = 0; index < length; index++) */
+/*     printf("pr[%d] = %f\n", index, pr[index]); */
+/*   return 0; */
+/* } */
+
+static PyObject * _print_array(PyObject * self, PyObject * args) {
   PyObject *float_list;
   int pr_length;
   double *pr;
@@ -31,14 +164,22 @@ static PyObject * print_array(PyObject * self, PyObject * args) {
     pr[index] = PyFloat_AsDouble(item);
   }
 
-  return Py_BuildValue("i", _print_array(pr, pr_length));
+  return Py_BuildValue("i", print_array(pr, pr_length));
 }
 
 static PyMethodDef ObsidianMethods[] = {
-  {"print_array", print_array, METH_VARARGS, "print array of floats"},
+  {"print_array", _print_array, METH_VARARGS, "print array of floats"},
   {NULL, NULL, 0, NULL}
 };
 
 PyMODINIT_FUNC initobsidian(void) {
   (void) Py_InitModule("obsidian", ObsidianMethods);
+  import_array();
+}
+
+int main(int argc, char** argv) {
+  Py_SetProgramName(argv[0]);
+  Py_Initialize();
+
+  initobsidian();
 }

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -133,7 +133,7 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
   if (!PyArg_ParseTuple(args, "dO", &duration, &state_obj))
     return NULL;
 
-  printf("duration !!!! %f\n", duration);
+  /* printf("duration !!!! %f\n", duration); */
 
   double * state = double_data_for(state_obj);
   evolve_result result = evolve(self->reactions_length,
@@ -150,14 +150,14 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
                                 duration,
                                 state);
   
-  printf("time: ");
-  print_array(result.time, result.steps);
+  /* printf("time: "); */
+  /* print_array(result.time, result.steps); */
 
-  printf("events: ");
-  print_long_array(result.events, result.steps);
+  /* printf("events: "); */
+  /* print_long_array(result.events, result.steps); */
 
-  printf("state: ");
-  print_array(result.state, self->substrates_length);
+  /* printf("state: "); */
+  /* print_array(result.state, self->substrates_length); */
 
   long steps[1];
   steps[0] = result.steps;
@@ -339,14 +339,9 @@ _invoke_obsidian(PyObject * self, PyObject * args) {
   int substrates_length = (int) PyArray_DIM(stoichiometry_array, 1);
   double * stoichiometry = (double *) PyArray_DATA(stoichiometry_array);
 
-  printf("dims - %d x %d\n", reactions_length, substrates_length);
-  print_array(stoichiometry, reactions_length * substrates_length);
-
   // import the rates as a 1d numpy array
   PyObject * rates_array = array_for(rates_obj, NPY_DOUBLE);
   double * rates = (double *) PyArray_DATA(rates_array);
-
-  print_array(rates, reactions_length);
 
   long * reactants_lengths = long_data_for(reactants_lengths_obj);
   long * reactants_indexes = long_data_for(reactants_indexes_obj);

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -6,12 +6,12 @@ static PyObject *ErrorObject;
 
 typedef struct {
   PyObject_HEAD
-  PyObject *x_attr;
+  PyObject * x_attr;
 } ObsidianObject;
 
 static PyTypeObject Obsidian_Type;
 
-#define ObsidianObject_Check(v)      (Py_TYPE(v) == &Obsidian_Type)
+#define ObsidianObject_Check(v) (Py_TYPE(v) == &Obsidian_Type)
 
 static ObsidianObject *
 newObsidianObject(PyObject *arg)
@@ -133,7 +133,8 @@ static PyTypeObject Obsidian_Type = {
 
 // https://dfm.io/posts/python-c-extensions/
 
-static PyObject * _print_array(PyObject * self, PyObject * args) {
+static PyObject *
+_print_array(PyObject * self, PyObject * args) {
   PyObject *float_list;
   int pr_length;
   double *pr;
@@ -159,6 +160,32 @@ static PyObject * _print_array(PyObject * self, PyObject * args) {
   }
 
   return Py_BuildValue("i", print_array(pr, pr_length));
+}
+
+static PyObject *
+_invoke_obsidian(PyObject * self, PyObject * args) {
+  ObsidianObject * obsidian;
+  PyObject * stoichiometry_obj,
+    rates_obj,
+    reactants_obj,
+    reactions_obj,
+    dependencies_obj;
+
+  if (!PyArg_ParseTuple(args,
+                        "OOOOO",
+                        &stoichiometry_obj,
+                        &rates_obj,
+                        &reactants_obj,
+                        &reactions_obj,
+                        &dependencies_obj))
+    return NULL;
+
+  PyObject * rates_array = PyArray_FROM_OTF(rates_obj, NPY_DOUBLE, NPY_IN_ARRAY);
+}
+
+static PyObject *
+_evolve(PyObject * self, PyObject * args) {
+
 }
 
 static PyMethodDef ObsidianMethods[] = {

--- a/arrow/reference.py
+++ b/arrow/reference.py
@@ -1,0 +1,193 @@
+from __future__ import absolute_import, division, print_function
+
+import numpy as np
+
+from arrow.math import multichoose
+import obsidian
+
+def derive_reactants(stoichiometry):
+    '''
+    Calculate the various derived values this Gillespie implementation uses extensively
+    to avoid recalculating these values every step or call to `evolve`.
+
+    Args:
+        stoichiometry: A matrix representing all of the reactions the system is capable of.
+            Each row is a reaction, and each column is a substrate.
+
+    Returns:
+        reactants: Array of indexes into each reactant (substrate consumed by the reaction)
+            for each reaction.
+        reactions: The value of the reaction for each reactant involved.
+        involved: Array of indexes for each substrate involved in the reaction (reactant or product).
+    '''
+
+    reactants = [
+        np.where(reaction < 0)[0]
+        for reaction in stoichiometry]
+
+    reactions = [
+        -stoichiometry[reaction, r]
+        for reaction, r in enumerate(reactants)]
+
+    involved = [
+        np.where(reaction != 0)[0]
+        for reaction in stoichiometry]
+
+    return reactants, reactions, involved
+
+def calculate_dependencies(stoichiometry):
+    '''
+    Find out which reactions depend on which other reactions. A dependency exists if one of the
+    reactants or products of a reaction is a substrate involved in another reaction.
+
+    Args:
+        stoichiometry: A matrix representing all of the reactions the system is capable of.
+            Each row is a reaction, and each column is a substrate.
+
+    Returns:
+        dependencies: Array of indexes for each reaction that points to other reactions that will
+            be affected by the reaction.
+    '''
+
+    dependencies = [
+        np.where(np.any(stoichiometry.T[reaction != 0] < 0, 0))[0]
+        for reaction in stoichiometry]
+
+    return dependencies
+
+def step(
+        stoichiometry,
+        rates,
+        state,
+        reactants=None,
+        reactions=None,
+        propensities=None,
+        update_reactions=None):
+    '''
+    Determines which reaction happens next and how much time passes before this event
+    given the stoichiometry, the rates of each reaction, and counts of all substrates.
+    '''
+
+    if reactants is None:
+        reactants, reactions, involved = derive_reactants(
+            stoichiometry)
+
+    if update_reactions is None:
+        n_reactions = stoichiometry.shape[0]
+
+        propensities = np.empty(n_reactions)
+        update_reactions = xrange(n_reactions)
+
+    for reaction in update_reactions:
+        propensities[reaction] = rates[reaction] * multichoose(
+            state[reactants[reaction]],
+            reactions[reaction])
+
+    total = propensities.sum()
+
+    if total == 0:
+        interval = 0
+        outcome = state
+        choice = None
+
+    else:
+        interval = np.random.exponential(1 / total)
+        random = np.random.uniform(0, 1) * total
+
+        progress = 0
+        for choice, span in enumerate(propensities):
+            progress += span
+            if random <= progress:
+                break
+
+        reaction = stoichiometry[choice]
+        outcome = state + reaction
+
+    return interval, outcome, choice, propensities
+
+
+def evolve(
+        stoichiometry,
+        rates,
+        state,
+        duration,
+        reactants=None,
+        reactions=None,
+        dependencies=None):
+    '''
+    Perform a series of steps in the Gillepsie algorithm until the given duration is reached.
+    '''
+
+    now = 0
+    time = [0]
+    counts = [state]
+    propensities = None
+    update_reactions = None
+    events = np.zeros(rates.shape)
+
+    if reactants is None or reactions is None:
+        reactants, reactions, involved = derive_reactants(
+            stoichiometry)
+
+    if dependencies is None:
+        dependencies = calculate_dependencies(stoichiometry)
+
+    while True:
+        interval, state, choice, propensities = step(
+            stoichiometry,
+            rates,
+            state,
+            reactants,
+            reactions,
+            propensities,
+            update_reactions)
+
+        now += interval
+
+        if choice is None or now > duration:
+            break
+
+        time.append(now)
+        counts.append(state)
+
+        events[choice] += 1
+
+        update_reactions = dependencies[choice]
+
+    time = np.array(time)
+    counts = np.array(counts)
+
+    return time, counts, events
+
+class GillespieReference(object):
+    '''
+    This is a pure python implementation of the Gillespie algorithm:
+    https://en.wikipedia.org/wiki/Gillespie_algorithm
+
+    It has been subsumed by the native implementation in C, Obsidian, but is still useful here as
+    reference to the algorithm.
+    '''
+
+    def __init__(self, stoichiometry, rates):
+        self.stoichiometry = stoichiometry
+        self.rates = rates
+
+        reactants, reactions, involved = derive_reactants(stoichiometry)
+
+        self.reactants = reactants
+        self.reactions = reactions
+        self.dependencies = calculate_dependencies(stoichiometry)
+
+    def step(self, state):
+        return step(self.stoichiometry, self.rates, state)
+
+    def evolve(self, state, duration):
+        return evolve(
+            self.stoichiometry,
+            self.rates,
+            state,
+            duration,
+            reactants=self.reactants,
+            reactions=self.reactions,
+            dependencies=self.dependencies)
+

--- a/arrow/reference.py
+++ b/arrow/reference.py
@@ -18,7 +18,8 @@ def derive_reactants(stoichiometric_matrix):
         reactants: Array of indexes into each reactant (substrate consumed by the
             reaction) for each reaction.
         reactant_stoichiometries: The value of the reaction for each reactant involved.
-        substrates: Array of indexes for each substrate involved in the reaction (reactant or product).
+        substrates: Array of indexes for each substrate involved in the reaction
+            (reactant or product).
     '''
 
     reactants = [
@@ -162,7 +163,7 @@ def evolve(
     counts = np.array(counts)
 
     return {
-        'steps': len(time),
+        'steps': len(events),
         'time': np.array(time),
         'events': np.array(events),
         'occurrences': occurrences,
@@ -182,7 +183,8 @@ class GillespieReference(object):
         self.stoichiometric_matrix = stoichiometric_matrix
         self.rates = rates
 
-        reactants, reactant_stoichiometries, substrates = derive_reactants(stoichiometric_matrix)
+        reactants, reactant_stoichiometries, substrates = derive_reactants(
+			stoichiometric_matrix)
 
         self.reactants = reactants
         self.reactant_stoichiometries = reactant_stoichiometries

--- a/arrow/test/__init__.py
+++ b/arrow/test/__init__.py
@@ -1,0 +1,1 @@
+from test_arrow import test_complexation

--- a/arrow/test/test_arrow.py
+++ b/arrow/test/test_arrow.py
@@ -16,7 +16,8 @@ import numpy as np
 import json
 import argparse
 
-from arrow import evolve, StochasticSystem
+from arrow import evolve, derive_reactants, calculate_dependencies, StochasticSystem
+import obsidian
 
 def test_equilibration():
     stoichiometric_matrix = np.array([
@@ -109,6 +110,27 @@ def test_complexation():
     print(time)
 
     return (time, counts, events)
+
+def test_obsidian():
+    stoichiometric_matrix = np.array([
+        [1, 1, -1, 0],
+        [-2, 0, 0, 1],
+        [-1, -1, 1, 0]])
+
+    rates = np.array([3, 1, 1]) * 0.01
+
+    reactants, reactions = derive_reactants(stoichiometric_matrix)
+    dependencies = calculate_dependencies(stoichiometric_matrix)
+
+    ob = obsidian.obsidian(
+        stoichiometric_matrix,
+        rates,
+        reactants,
+        reactions,
+        dependencies)
+
+    assert(ob.reactions_length() == stoichiometric_matrix.shape[0])
+    assert(ob.substrates_length() == stoichiometric_matrix.shape[1])
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/arrow/test/test_arrow.py
+++ b/arrow/test/test_arrow.py
@@ -120,12 +120,12 @@ def test_obsidian():
     stoichiometric_matrix = np.array([
         [1, 1, -1, 0],
         [-2, 0, 0, 1],
-        [-1, -1, 1, 0]])
+        [-1, -1, 1, 0]], np.int64)
 
     rates = np.array([3, 1, 1]) * 0.01
 
     arrow = Arrow(stoichiometric_matrix, rates)
-    result = arrow.evolve(1.0, np.array([50, 20, 30, 40]))
+    result = arrow.evolve(1.0, np.array([50, 20, 30, 40], np.int64))
 
     print('steps: {}'.format(result['steps']))
     print('time: {}'.format(result['time']))

--- a/arrow/test/test_arrow.py
+++ b/arrow/test/test_arrow.py
@@ -154,7 +154,12 @@ def test_obsidian():
         dependencies_indexes,
         dependencies_flat)
 
-		# 5, 5, 5)
+    steps, time, events, state = ob.evolve(1.0, np.array([50, 20, 30, 40]))
+
+    print('steps: {}'.format(steps))
+    print('time: {}'.format(time))
+    print('events: {}'.format(events))
+    print('state: {}'.format(state))
 
     assert(ob.reactions_length() == stoichiometric_matrix.shape[0])
     assert(ob.substrates_length() == stoichiometric_matrix.shape[1])

--- a/arrow/test/test_arrow.py
+++ b/arrow/test/test_arrow.py
@@ -111,6 +111,9 @@ def test_complexation():
 
     return (time, counts, events)
 
+def flatten(l):
+    return [item for sublist in l for item in sublist]
+
 def test_obsidian():
     stoichiometric_matrix = np.array([
         [1, 1, -1, 0],
@@ -119,15 +122,39 @@ def test_obsidian():
 
     rates = np.array([3, 1, 1]) * 0.01
 
-    reactants, reactions = derive_reactants(stoichiometric_matrix)
-    dependencies = calculate_dependencies(stoichiometric_matrix)
+    reactants, reactions = derive_reactants(stoichiometric_matrix.T)
+    dependencies = calculate_dependencies(stoichiometric_matrix.T)
+
+    reactants_lengths = np.array([
+        len(reactant)
+        for reactant in reactants])
+    reactants_indexes = np.insert(reactants_lengths, 0, 0).cumsum()[:-1]
+    reactants_flat = np.array(flatten(reactants))
+    reactions_flat = np.array(flatten(reactions))
+
+    dependencies_lengths = np.array([
+        len(dependency)
+        for dependency in dependencies])
+    dependencies_indexes = np.insert(dependencies_lengths, 0, 0).cumsum()[:-1]
+    dependencies_flat = np.array(flatten(dependencies))
+
+    print('\nstoichiometry:\n {}'.format(stoichiometric_matrix))
+    print('reactants:\n {}\n {}\n {} -> {}'.format(reactants_lengths, reactants_indexes, reactants, reactants_flat))
+    print('reactions: {} -> {}'.format(reactions, reactions_flat))
+    print('dependencies: {} {} {}'.format(dependencies_lengths, dependencies_indexes, dependencies_flat))
 
     ob = obsidian.obsidian(
         stoichiometric_matrix,
         rates,
-        reactants,
-        reactions,
-        dependencies)
+        reactants_lengths,
+        reactants_indexes,
+        reactants_flat,
+        reactions_flat,
+        dependencies_lengths,
+        dependencies_indexes,
+        dependencies_flat)
+
+		# 5, 5, 5)
 
     assert(ob.reactions_length() == stoichiometric_matrix.shape[0])
     assert(ob.substrates_length() == stoichiometric_matrix.shape[1])

--- a/arrow/test/test_arrow.py
+++ b/arrow/test/test_arrow.py
@@ -135,8 +135,8 @@ def test_obsidian():
     print('occurrences: {}'.format(result['occurrences']))
     print('outcome: {}'.format(result['outcome']))
 
-    assert(arrow.obsidian.reactions_length() == stoichiometric_matrix.shape[0])
-    assert(arrow.obsidian.substrates_length() == stoichiometric_matrix.shape[1])
+    assert(arrow.obsidian.reactions_count() == stoichiometric_matrix.shape[0])
+    assert(arrow.obsidian.substrates_count() == stoichiometric_matrix.shape[1])
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/arrow/test/test_arrow.py
+++ b/arrow/test/test_arrow.py
@@ -94,10 +94,6 @@ def test_complexation():
     # semi-quantitative rate constants
     rates = np.full(n_reactions, 1000)
 
-    # system = GillespieReference(stoichiometric_matrix, rates)
-    # time, counts, events = system.evolve(initial_state, duration)
-    # outcome = counts[-1]
-
     system = StochasticSystem(stoichiometric_matrix, rates)
     result = system.evolve(duration, initial_state)
 

--- a/arrow/test/test_arrow.py
+++ b/arrow/test/test_arrow.py
@@ -93,6 +93,8 @@ def test_complexation():
 
     system = StochasticSystem(stoichiometric_matrix, rates)
 
+    # import ipdb; ipdb.set_trace()
+
     time, counts, events = system.evolve(initial_state, duration)
 
     assert(len(time)-1 == events.sum())

--- a/arrow/test/test_arrow.py
+++ b/arrow/test/test_arrow.py
@@ -91,15 +91,21 @@ def test_complexation():
     duration = 1
 
     # semi-quantitative rate constants
-    rates = np.full(n_reactions, 10)
+    rates = np.full(n_reactions, 1000)
 
-    system = StochasticSystem(stoichiometric_matrix, rates)
+    # system = StochasticSystem(stoichiometric_matrix, rates)
+    # time, counts, events = system.evolve(initial_state, duration)
+    # outcome = counts[-1]
 
-    time, counts, events = system.evolve(initial_state, duration)
+    system = Arrow(stoichiometric_matrix.T, rates)
+    result = system.evolve(duration, initial_state)
 
-    assert(len(time)-1 == events.sum())
+    time = result['time']
+    events = result['occurrences']
+    outcome = result['outcome']
 
-    outcome = counts[-1]
+    assert(len(time) == int(events.sum()))
+
     difference = (final_state - outcome)
 
     total = np.abs(difference).sum()
@@ -108,7 +114,7 @@ def test_complexation():
     print('total steps: {}'.format(len(time)))
     print(time)
 
-    return (time, counts, events)
+    return (time, outcome, events)
 
 def test_obsidian():
     stoichiometric_matrix = np.array([

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,20 @@
+import os
+import glob
 import setuptools
-from distutils.core import setup
+from distutils.core import setup, Extension
+import numpy.distutils.misc_util
+
+sources = glob.glob('arrow/*.c')
+obsidian = Extension('obsidian', sources=sources)
 
 with open("README.md", 'r') as readme:
 	long_description = readme.read()
+
+current_dir = os.getcwd()
+arrow_dir = os.path.join(current_dir, 'arrow')
+include = [arrow_dir] + numpy.distutils.misc_util.get_numpy_include_dirs()
+
+print include
 
 setup(
 	name='stochastic-arrow',
@@ -12,5 +24,7 @@ setup(
 	author_email='spanglry@stanford.edu',
 	url='https://github.com/CovertLab/arrow',
 	license='MIT',
+	include_dirs=include,
+	ext_modules=[obsidian],
 	long_description=long_description,
 	long_description_content_type='text/markdown')

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ print include
 
 setup(
 	name='stochastic-arrow',
-	version='0.0.15',
+	version='0.0.16',
 	packages=['arrow'],
 	author='Ryan Spangler',
 	author_email='spanglry@stanford.edu',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ include = [arrow_dir] + numpy.distutils.misc_util.get_numpy_include_dirs()
 
 setup(
 	name='stochastic-arrow',
-	version='0.0.18',
+	version='0.1.0',
 	packages=['arrow'],
 	author='Ryan Spangler',
 	author_email='spanglry@stanford.edu',

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import setuptools
 from distutils.core import setup, Extension
 import numpy.distutils.misc_util
 
+headers = glob.glob('arrow/*.h')
 sources = glob.glob('arrow/*.c')
 obsidian = Extension('obsidian', sources=sources)
 
@@ -18,7 +19,7 @@ print include
 
 setup(
 	name='stochastic-arrow',
-	version='0.0.12',
+	version='0.0.15',
 	packages=['arrow'],
 	author='Ryan Spangler',
 	author_email='spanglry@stanford.edu',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", 'r') as readme:
 
 setup(
 	name='stochastic-arrow',
-	version='0.0.8',
+	version='0.0.11',
 	packages=['arrow'],
 	author='Ryan Spangler',
 	author_email='spanglry@stanford.edu',

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,9 @@ current_dir = os.getcwd()
 arrow_dir = os.path.join(current_dir, 'arrow')
 include = [arrow_dir] + numpy.distutils.misc_util.get_numpy_include_dirs()
 
-print include
-
 setup(
 	name='stochastic-arrow',
-	version='0.0.16',
+	version='0.0.18',
 	packages=['arrow'],
 	author='Ryan Spangler',
 	author_email='spanglry@stanford.edu',


### PR DESCRIPTION
This PR dispenses struggling with trying to make python fast and appeals directly to C, the source of all things. 

The python interface is the same (though it returns a dictionary instead of a tuple as the values returned were growing), but instead of using the now reference python implementation the arguments are translated from python into C arrays and passed to a pure C Gillespie implementation. Comparing the two:

```
reference time elapsed: 2.04260396957
obsidian time elapsed: 0.0289080142975
```

This is in the range of two orders of magnitude, or over 70x faster. Luckily for us, the Gillespie algorithm can never run too fast, so some day I hope to see this realized: https://www.ncbi.nlm.nih.gov/pubmed/19162916 (anyone know who the FPGA people are on campus? I have already asked several of you). Until then, we have C. Which will suffice for now.

I go into great detail about the design and algorithm throughout the code so I will avoid that here. The main entry point and translation from python occurs in `obsidianmodule.c` and the Gillespie implementation is in `obsidian.c` with a header at `obsidian.h`, in the `evolve` function. Any and all questions/suggestions/thoughts/revelations welcome, thanks!