### PR TITLE
Decrement references to arrays before returning them

### DIFF
--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -229,11 +229,11 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
   Py_XDECREF(state_array);
 
   // Construct the return value that will be ultimately visible to python
-  PyObject * ret = Py_BuildValue("iOOO",
-                                 result.steps,
-                                 time_obj,
-                                 events_obj,
-                                 outcome_obj);
+  PyObject *ret = Py_BuildValue("iOOO",
+                                result.steps,
+                                time_obj,
+                                events_obj,
+                                outcome_obj);
 
   Py_XDECREF(time_obj);
   Py_XDECREF(events_obj);

--- a/arrow/obsidianmodule.c
+++ b/arrow/obsidianmodule.c
@@ -229,11 +229,17 @@ Obsidian_evolve(ObsidianObject *self, PyObject *args)
   Py_XDECREF(state_array);
 
   // Construct the return value that will be ultimately visible to python
-  return Py_BuildValue("iOOO",
-                       result.steps,
-                       time_obj,
-                       events_obj,
-                       outcome_obj);
+  PyObject * ret = Py_BuildValue("iOOO",
+                                 result.steps,
+                                 time_obj,
+                                 events_obj,
+                                 outcome_obj);
+
+  Py_XDECREF(time_obj);
+  Py_XDECREF(events_obj);
+  Py_XDECREF(outcome_obj);
+
+  return ret;
 }
 
 // Declare the various methods that an Obsidian object will have and align them with

--- a/arrow/test/test_arrow.py
+++ b/arrow/test/test_arrow.py
@@ -184,6 +184,7 @@ def test_memory():
     this = psutil.Process(os.getpid())
     memory = 0
     memory_previous = 0
+    memory_increases = 0
 
     system = StochasticSystem(stoichiometric_matrix, rates, random_seed=np.random.randint(2**31))
     obsidian_start = time.time()
@@ -192,6 +193,7 @@ def test_memory():
         if (memory != memory_previous):
             print('memory increase iteration {}: {}'.format(i, memory))
             memory_previous = memory
+            memory_increases += 1
 
         result = system.evolve(duration, initial_state)
         difference = np.abs(final_state - result['outcome']).sum()
@@ -199,6 +201,7 @@ def test_memory():
         print('difference is {}'.format(difference))
     obsidian_end = time.time()
 
+    assert(memory_increases <= 1)
     print('obsidian time elapsed: {}'.format(obsidian_end - obsidian_start))
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ include = [arrow_dir] + numpy.distutils.misc_util.get_numpy_include_dirs()
 
 setup(
 	name='stochastic-arrow',
-	version='0.1.7',
+	version='0.1.8',
 	packages=['arrow'],
 	author='Ryan Spangler',
 	author_email='spanglry@stanford.edu',


### PR DESCRIPTION
Apparently beyond the memory leak I fixed before, there was also a reference counting error in returning values to python. As it turns out, putting the arrays into the "return tuple" required by python increments the reference count to each, which in addition to the references from instantiating them means these arrays were never released. Since this is at the python-machinery level instead of the C level I missed this before.

I did some memory profiling at the python level to ensure no more references are being missed, but things look solid after this change.