### PR TITLE
Adjustment to API to pass rates into evolve() instead of __init__()

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,13 @@ stoichiometric_matrix = np.array([
     [-2, 0, 0, 1],
     [-1, -1, 1, 0]], np.int64)
 
-# Each reaction has an associated rate for how probable that reaction is.
-rates = np.array([3.0, 1.0, 1.0])
-
-# Once we have a matrix of reactions and their associated rates, we can
+# Once we have a matrix of reactions, we can
 # construct the system.
-system = StochasticSystem(stoichiometric_matrix, rates)
+system = StochasticSystem(stoichiometric_matrix)
 ```
 
 Now that the system has been instantiated, we can invoke it with any initial
-state vector and then run it for a given time interval:
+state vector and set of reaction rates and then run it for a given time interval:
 
 ```python
 # This gives the initial state of the system (counts of each molecular species,
@@ -58,9 +55,12 @@ state = np.array([1000, 1000, 0, 0])
 # We also specify how long we want the simulation to run. Here we set it to one
 # second.
 duration = 1
+
+# Each reaction has an associated rate for how probable that reaction is.
+rates = np.array([3.0, 1.0, 1.0])
 ```
 
-Once we have an initial state and duration, we can run the simulation for the
+Once we have an initial state and rates, we can run the simulation for the
 given duration. `evolve` returns a dictionary with five keys:
 
 * steps - the number of steps the simulation took
@@ -70,7 +70,7 @@ given duration. `evolve` returns a dictionary with five keys:
 * outcome - the final state of the system
 
 ```python
-result = system.evolve(state, duration)
+result = system.evolve(state, duration, rates)
 ```
 
 If you are interested in the history of states for plotting or otherwise, these can be

--- a/README.md
+++ b/README.md
@@ -103,3 +103,9 @@ There are more command line features in test_arrow:
     > python -m arrow.test.test_arrow --memory
 
     > python -m arrow.test.test_arrow --time
+
+## Changelog
+
+### Version 0.3.0
+
+* Introduced backwards-incompatible API change for supplying rates at `evolve()` time rather than `__init__()` for `StochasticSystem`.

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -84,7 +84,7 @@ class StochasticSystem(object):
     def __init__(self, stoichiometry, random_seed=0):
         '''
         This invokes the Obsidian C code (via arrowhead.pyx) with the
-        stoichiometry, reaction rates and a variety of derived values. Once constructed,
+        stoichiometry and a variety of derived values. Once constructed,
         this can be invoked by calling `evolve` with a duration and initial state, since
         the stoichiometry will be shared among all calls.
 

--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -81,7 +81,7 @@ class StochasticSystem(object):
     (and zero everywhere else). 
     '''
 
-    def __init__(self, stoichiometry, rates, random_seed=0):
+    def __init__(self, stoichiometry, random_seed=0):
         '''
         This invokes the Obsidian C code (via arrowhead.pyx) with the
         stoichiometry, reaction rates and a variety of derived values. Once constructed,
@@ -102,8 +102,6 @@ class StochasticSystem(object):
         '''
 
         self.stoichiometry = stoichiometry.copy()
-        self.rates = rates
-
         self.random_seed = random_seed
 
         reactants, reactions, substrates = derive_reactants(stoichiometry)
@@ -118,7 +116,6 @@ class StochasticSystem(object):
         self.obsidian = Arrowhead(
             self.random_seed,
             self.stoichiometry,
-            self.rates,
             self.reactants_lengths,
             self.reactants_indexes,
             self.reactants_flat,
@@ -130,9 +127,9 @@ class StochasticSystem(object):
             self.substrates_indexes,
             self.substrates_flat)
 
-    def evolve(self, duration, state):
-        steps, time, events, outcome = self.obsidian.evolve(duration, state)
-        occurrences = np.zeros(len(self.rates))
+    def evolve(self, duration, state, rates):
+        steps, time, events, outcome = self.obsidian.evolve(duration, state, rates)
+        occurrences = np.zeros(len(rates))
         for event in events:
             occurrences[event] += 1
 

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -77,13 +77,12 @@ choose(int64_t n, int64_t k) {
 //   * events: An array of length `steps` signifying which reaction took place at
 //       each time point
 //   * outcome: The final state after all of the reactions have been performed.
-evolve_result evolve(Info *info, double duration, int64_t *state) {
+evolve_result evolve(Info *info, double duration, int64_t *state, double *rates) {
   MTState *random_state = info->random_state;
 
   int reactions_count = info->reactions_count;
   int substrates_count = info->substrates_count;
   int64_t *stoichiometry = info->stoichiometry;
-  double *rates = info->rates;
 
   int64_t *reactants_lengths = info->reactants_lengths;
   int64_t *reactants_indexes = info->reactants_indexes;

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -17,7 +17,6 @@ typedef struct Info {
     int reactions_count;
     int substrates_count;
     int64_t *stoichiometry;
-    double *rates;
 
     int64_t *reactants_lengths;
     int64_t *reactants_indexes;
@@ -36,7 +35,7 @@ typedef struct Info {
 // Invoke the system with all the required information to run for the given duration.
 // The result is either a failure = {-1, NULL, NULL, NULL} or it points to malloc'd
 // arrays that the caller must free().
-evolve_result evolve(Info *info, double duration, int64_t *state);
+evolve_result evolve(Info *info, double duration, int64_t *state, double *rates);
 
 // Supporting print utilities
 int print_array(double *array, int length);

--- a/arrow/obsidian.pxd
+++ b/arrow/obsidian.pxd
@@ -19,7 +19,7 @@ cdef extern from "obsidian.h":
         int reactions_count
         int substrates_count
         int64_t *stoichiometry
-        double *rates
+        # double *rates
 
         int64_t *reactants_lengths
         int64_t *reactants_indexes
@@ -34,6 +34,6 @@ cdef extern from "obsidian.h":
         int64_t *substrates_indexes
         int64_t *substrates
 
-    evolve_result evolve(Info *info, double duration, int64_t *state)
+    evolve_result evolve(Info *info, double duration, int64_t *state, double *rates)
 
     int print_array(double *array, int length)

--- a/arrow/reference.py
+++ b/arrow/reference.py
@@ -180,9 +180,8 @@ class GillespieReference(object):
     useful here as reference to the algorithm.
     '''
 
-    def __init__(self, stoichiometric_matrix, rates):
+    def __init__(self, stoichiometric_matrix):
         self.stoichiometric_matrix = stoichiometric_matrix
-        self.rates = rates
 
         reactants, reactant_stoichiometries, substrates = derive_reactants(
             stoichiometric_matrix)
@@ -191,13 +190,13 @@ class GillespieReference(object):
         self.reactant_stoichiometries = reactant_stoichiometries
         self.dependencies = calculate_dependencies(stoichiometric_matrix)
 
-    def step(self, state):
-        return step(self.stoichiometric_matrix, self.rates, state)
+    def step(self, state, rates):
+        return step(self.stoichiometric_matrix, rates, state)
 
-    def evolve(self, duration, state):
+    def evolve(self, duration, state, rates):
         return evolve(
             self.stoichiometric_matrix,
-            self.rates,
+            rates,
             state,
             duration,
             reactants=self.reactants,

--- a/arrow/test/test_arrow.py
+++ b/arrow/test/test_arrow.py
@@ -29,12 +29,12 @@ def test_equilibration():
         [-1, +1]])
 
     rates = np.array([10, 10, 0.1])
-    system = GillespieReference(stoichiometric_matrix, rates)
+    system = GillespieReference(stoichiometric_matrix)
 
     state = np.array([1000, 0])
     duration = 10
 
-    result = system.evolve(duration, state)
+    result = system.evolve(duration, state, rates)
 
     time = result['time']
     counts = reenact_events(stoichiometric_matrix, result['events'], state)
@@ -53,12 +53,12 @@ def test_dimerization():
         [-1, -1, 1, 0]], np.int64)
 
     rates = np.array([3, 1, 1]) * 0.01
-    system = GillespieReference(stoichiometric_matrix, rates)
+    system = GillespieReference(stoichiometric_matrix)
 
     state = np.array([1000, 1000, 0, 0])
     duration = 1
 
-    result = system.evolve(duration, state)
+    result = system.evolve(duration, state, rates)
 
     time = result['time']
     counts = reenact_events(stoichiometric_matrix, result['events'], state)
@@ -159,10 +159,10 @@ def test_compare_runtime():
     duration = 1
     amplify = 100
 
-    reference = GillespieReference(stoichiometric_matrix, rates)
+    reference = GillespieReference(stoichiometric_matrix)
     reference_start = seconds_since_epoch()
     for i in range(amplify):
-        result = reference.evolve(duration, initial_state)
+        result = reference.evolve(duration, initial_state, rates)
     reference_end = seconds_since_epoch()
 
     system = StochasticSystem(stoichiometric_matrix)

--- a/arrow/test/test_arrow.py
+++ b/arrow/test/test_arrow.py
@@ -107,8 +107,8 @@ def complexation_test(make_system):
     stoichiometric_matrix, rates, initial_state, final_state = load_complexation(prefix='simple')
     duration = 1
 
-    system = make_system(stoichiometric_matrix, rates)
-    result = system.evolve(duration, initial_state)
+    system = make_system(stoichiometric_matrix)
+    result = system.evolve(duration, initial_state, rates)
 
     time = np.concatenate([[0.0], result['time']])
     events = result['events']
@@ -142,8 +142,8 @@ def test_obsidian():
 
     rates = np.array([3, 1, 1]) * 0.01
 
-    arrow = StochasticSystem(stoichiometric_matrix, rates)
-    result = arrow.evolve(1.0, np.array([50, 20, 30, 40], np.int64))
+    arrow = StochasticSystem(stoichiometric_matrix)
+    result = arrow.evolve(1.0, np.array([50, 20, 30, 40], np.int64), rates)
 
     print('steps: {}'.format(result['steps']))
     print('time: {}'.format(result['time']))
@@ -165,10 +165,10 @@ def test_compare_runtime():
         result = reference.evolve(duration, initial_state)
     reference_end = seconds_since_epoch()
 
-    system = StochasticSystem(stoichiometric_matrix, rates)
+    system = StochasticSystem(stoichiometric_matrix)
     obsidian_start = seconds_since_epoch()
     for i in range(amplify):
-        result = system.evolve(duration, initial_state)
+        result = system.evolve(duration, initial_state, rates)
     obsidian_end = seconds_since_epoch()
 
     print('reference Python implementation elapsed seconds: {}'.format(
@@ -186,7 +186,7 @@ def test_memory():
     memory_increases = 0
     print('initial memory use: {}'.format(memory))
 
-    system = StochasticSystem(stoichiometric_matrix, rates, random_seed=np.random.randint(2**31))
+    system = StochasticSystem(stoichiometric_matrix, random_seed=np.random.randint(2**31))
 
     obsidian_start = seconds_since_epoch()
     for i in range(1, amplify + 1):
@@ -196,7 +196,7 @@ def test_memory():
             memory_previous = memory
             memory_increases += 1
 
-        result = system.evolve(duration, initial_state)
+        result = system.evolve(duration, initial_state, rates)
         difference = np.abs(final_state - result['outcome']).sum()
 
         if difference:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ ext = '.pyx' if USE_CYTHON else '.c'
 
 cython_extensions = [
 	Extension('arrow.arrowhead',
-			  sources=['arrow/arrowhead'+ext, 'arrow/mersenne.c', 'arrow/obsidian.c',],
+			  sources=['arrow/mersenne.c', 'arrow/obsidian.c', 'arrow/arrowhead'+ext,],
 			  include_dirs=['arrow'],
 			  define_macros=[('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')],
 			  )]
@@ -39,7 +39,7 @@ if USE_CYTHON:
 
 setup(
 	name='stochastic-arrow',
-	version='0.2.0',
+	version='0.2.1',
 	packages=['arrow'],
 	author='Ryan Spangler, John Mason, Jerry Morrison',
 	author_email='spanglry@stanford.edu',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if USE_CYTHON:
 
 setup(
 	name='stochastic-arrow',
-	version='0.2.1',
+	version='0.3.0',
 	packages=['arrow'],
 	author='Ryan Spangler, John Mason, Jerry Morrison',
 	author_email='spanglry@stanford.edu',


### PR DESCRIPTION
While applying Arrow to some problems in Vivarium, I came across the need to pass in the rates to the system each time I call it (dynamics rates), rather than supplying them when the system is initialized (static rates). To support this, I shifted the `__init__` for `StochasticSystem` to take only the stoichiometry and then pass in the rates to the call to `evolve`. This is mostly an API change as the essential implementation doesn't care when the rates appeared, it just indexes into them when necessary. 