### PR TITLE
Detecting when propensities overflow

### DIFF
--- a/arrow/arrow.py
+++ b/arrow/arrow.py
@@ -128,7 +128,11 @@ class StochasticSystem(object):
             self.substrates_flat)
 
     def evolve(self, duration, state, rates):
-        steps, time, events, outcome = self.obsidian.evolve(duration, state, rates)
+        status, steps, time, events, outcome = self.obsidian.evolve(duration, state, rates)
+
+        if status > 0:
+            raise SimulationFailure(status)
+
         occurrences = np.zeros(len(rates))
         for event in events:
             occurrences[event] += 1
@@ -139,3 +143,9 @@ class StochasticSystem(object):
             'events': events,
             'occurrences': occurrences,
             'outcome': outcome}
+
+
+class SimulationFailure(Exception):
+    def __init__(self, status):
+        self.status = status
+        super(SimulationFailure, self).__init__()

--- a/arrow/arrowhead.pyx
+++ b/arrow/arrowhead.pyx
@@ -100,11 +100,12 @@ cdef class Arrowhead:
     def evolve(self, double duration, int64_t[::1] state, double[::1] rates):
         """Run the Gillespie algorithm with the initialized stoichiometry and
         rates over the given duration and state.
-        Return None or a tuple (steps, time, events, outcome).
+        Return None or a tuple (status, steps, time, events, outcome).
         """
         # TODO(jerry): Check the state[] array size?
 
         evolved = obsidian.evolve(&self.info, duration, &state[0], &rates[0])
+        cdef int status = evolved.status
         cdef int steps = evolved.steps
         cdef int count = self.info.substrates_count
 
@@ -115,7 +116,7 @@ cdef class Arrowhead:
         events = copy_c_array(evolved.events, steps, sizeof(int64_t), np.NPY_INT64)
         outcome = copy_c_array(evolved.outcome, count, sizeof(int64_t), np.NPY_INT64)
 
-        result = steps, time, events, outcome
+        result = status, steps, time, events, outcome
 
         free(evolved.time)
         free(evolved.events)

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -11,7 +11,7 @@
 static const int INITIAL_LENGTH = 4000;
 
 // Create a value to represent failures
-static const evolve_result failure = {-1, NULL, NULL, NULL};
+static const evolve_result failure = {2, -1, NULL, NULL, NULL};
 
 // Find the number of combinations of choosing k selections from n items
 double
@@ -113,6 +113,10 @@ evolve_result evolve(Info *info, double duration, int64_t *state, double *rates)
   int64_t *update = malloc((sizeof (int64_t)) * reactions_count);
   int64_t update_length = reactions_count;
 
+  // if something goes wrong (like an overflow in propensities), the status will be
+  // set to some meaningful number
+  int64_t status = 0;
+
   if (time == NULL ||
       events == NULL ||
       outcome == NULL ||
@@ -184,7 +188,9 @@ evolve_result evolve(Info *info, double duration, int64_t *state, double *rates)
         }
       }
       printf("largest reaction is %d at %f\n", max_reaction, propensities[max_reaction]);
-      total = 0.0;
+      interval = 0.0;
+      choice = -1;
+      status = 1; // overflow
     }
 
     // If the total is zero, then we have no more reactions to perform and can exit
@@ -289,11 +295,12 @@ evolve_result evolve(Info *info, double duration, int64_t *state, double *rates)
   // Construct the `evolve_result` from the results of performing steps until either
   // the desired duration was achieved or there are no more reactions to perform.
   // We return:
+  //   * The status of the simulation (0 == success)
   //   * How many steps were performed
   //   * An array of the time of each event
   //   * An array of each event that occurred each time step
   //   * The resulting state of the system after the chosen reactions were applied
-  evolve_result result = {step, time, events, outcome};
+  evolve_result result = {status, step, time, events, outcome};
 
   // Clean up the transient allocations
   free(propensities);

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -167,7 +167,6 @@ evolve_result evolve(Info *info, double duration, int64_t *state, double *rates)
       // by the reaction's original rate and the contributions from other reactants
       for (reactant = 0; reactant < reactants_lengths[reaction]; reactant++) {
         index = reactants_indexes[reaction] + reactant;
-
         count = outcome[reactants[index]];
         propensities[reaction] *= choose(count, reactions[index]);
       }
@@ -180,7 +179,7 @@ evolve_result evolve(Info *info, double duration, int64_t *state, double *rates)
     }
 
     if (isnan(total)) {
-      printf("failed simulation: total propensity is NAN\n");
+      printf("failed simulation: total propensity is NaN\n");
       int max_reaction = 0;
       for (reaction = 0; reaction < reactions_count; reaction++) {
         if (propensities[reaction] > propensities[max_reaction]) {

--- a/arrow/obsidian.c
+++ b/arrow/obsidian.c
@@ -175,6 +175,18 @@ evolve_result evolve(Info *info, double duration, int64_t *state, double *rates)
       total += propensities[reaction];
     }
 
+    if (isnan(total)) {
+      printf("failed simulation: total propensity is NAN\n");
+      int max_reaction = 0;
+      for (reaction = 0; reaction < reactions_count; reaction++) {
+        if (propensities[reaction] > propensities[max_reaction]) {
+          max_reaction = reaction;
+        }
+      }
+      printf("largest reaction is %d at %f\n", max_reaction, propensities[max_reaction]);
+      total = 0.0;
+    }
+
     // If the total is zero, then we have no more reactions to perform and can exit
     // early
     if (total <= 0.0) {

--- a/arrow/obsidian.h
+++ b/arrow/obsidian.h
@@ -5,6 +5,7 @@
 
 // The structure for holding the result of the Gillespie algorithm
 typedef struct evolve_result {
+  int status;        // 0 --> success otherwise failure
   int steps;         // -1 => failure
   double *time;      // double time[steps]
   int64_t *events;   // int64_t events[steps]

--- a/arrow/obsidian.pxd
+++ b/arrow/obsidian.pxd
@@ -8,6 +8,7 @@ from mersenne cimport MTState
 cdef extern from "obsidian.h":
 
     ctypedef struct evolve_result:
+        int status        # 0 => success
         int steps         # -1 => failure
         double *time      # double time[steps]
         int64_t *events   # int64_t events[steps]

--- a/arrow/test/negative_counts.py
+++ b/arrow/test/negative_counts.py
@@ -10,7 +10,7 @@ with open('data/complexation/large-initial.json') as f:
     data = json.load(f)
 
 stoich = np.array(data['stoich'])
-rates = np.array(data['rates'])
+rates = np.array(data['rates']) * 1e-30
 counts = np.array(data['counts'])
 
 system = StochasticSystem(stoich.T, random_seed=0)

--- a/arrow/test/negative_counts.py
+++ b/arrow/test/negative_counts.py
@@ -1,0 +1,30 @@
+import json
+
+from arrow import StochasticSystem
+import numpy as np
+
+
+duration = 2**31
+
+with open('data/complexation/large-initial.json') as f:
+    data = json.load(f)
+
+stoich = np.array(data['stoich'])
+rates = np.array(data['rates'])
+counts = np.array(data['counts'])
+
+system = StochasticSystem(stoich.T, random_seed=0)
+
+while True:
+    result = system.evolve(duration, counts, rates)
+
+    updated_counts = result['outcome']
+
+    if not np.any(counts - updated_counts):
+        break
+
+    if np.any(updated_counts < 0):
+        raise Exception('Negative counts')
+    
+    counts = updated_counts
+    print(counts)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if USE_CYTHON:
 
 setup(
 	name='stochastic-arrow',
-	version='0.3.0',
+	version='0.3.1',
 	packages=['arrow'],
 	author='Ryan Spangler, John Mason, Jerry Morrison',
 	author_email='spanglry@stanford.edu',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if USE_CYTHON:
 
 setup(
 	name='stochastic-arrow',
-	version='0.3.1',
+	version='0.4.0',
 	packages=['arrow'],
 	author='Ryan Spangler, John Mason, Jerry Morrison',
 	author_email='spanglry@stanford.edu',


### PR DESCRIPTION
We have had a couple incidents where propensity calculations overflow when grappling with large counts of massive complexes. Previously this would fail silently and exhibit in terms of negative counts or in one case an infinite loop. 

I have added some simple logic to detect when the total propensity becomes NaN and abort the simulation. It also prints out a helpful error message pointing towards the reaction with the largest propensity, so that the client can refactor the stoichiometry for this reaction to something more reasonable/tractable/computable in 64-bit floating point registers. 

Example output: 

```
failed simulation: total propensity is NAN
largest reaction is 390 at 65750108189886363191576674736750174090067616495572572584950851546902195800567499629394079127738955399755607759040963476860612556881920.000000
```