### PR TITLE
Fix Build Failure by Including Numpy Include Dirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ ext = '.pyx' if USE_CYTHON else '.c'
 cython_extensions = [
 	Extension('arrow.arrowhead',
 			  sources=['arrow/mersenne.c', 'arrow/obsidian.c', 'arrow/arrowhead'+ext,],
-			  include_dirs=['arrow'],
+			  include_dirs=['arrow'] + numpy.distutils.misc_util.get_numpy_include_dirs(),
 			  define_macros=[('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')],
 			  )]
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if USE_CYTHON:
 
 setup(
 	name='stochastic-arrow',
-	version='0.4.0',
+	version='0.4.1',
 	packages=['arrow'],
 	author='Ryan Spangler, John Mason, Jerry Morrison',
 	author_email='spanglry@stanford.edu',


### PR DESCRIPTION
## Summary

I encountered build failures when installing `stochastic-arrow` from PyPi for Vivarium.
The build was failing with an error finding numpy.arrayobject.h. This
commit fixes the problem by adding the Numpy include directories to the
Extension `include_dirs` list.

Fix was informed by https://stackoverflow.com/a/14657667.

## Demonstration
Here are the steps I followed:
* I cloned the ``arrow`` repository (ba4bf0c70509c96672560b40d3b5dffb7089b5a7)
* I created a virtual environment with ``python3 -m venv venv``
* I installed the requirements into the virtual environment: ``pip -r requirements.txt``

### Before Fix

```
$ make clean
rm -rf arrow/arrowhead*.so arrow/arrowhead.c arrow/arrowhead.html build/ dist/ MANIFEST .pytest_cache/ stochastic_arrow.egg-info/
find . -name "*.pyc" -delete
find . -name "__pycache__" -delete
$ make compile
USE_CYTHON=1 python setup.py build_ext --inplace
Compiling arrow/arrowhead.pyx because it changed.
[1/1] Cythonizing arrow/arrowhead.pyx
running build_ext
building 'arrow.arrowhead' extension
C compiler: clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -I/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers

creating build
creating build/temp.macosx-10.15-x86_64-3.7
creating build/temp.macosx-10.15-x86_64-3.7/arrow
compile options: '-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -Iarrow -I/usr/local/include -I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/sqlite/include -I/pathToArrow/arrow/venv/include -I/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/include/python3.7m -c'
clang: arrow/arrowhead.c
arrow/arrowhead.c:624:10: fatal error: 'numpy/arrayobject.h' file not found
#include "numpy/arrayobject.h"
         ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
arrow/arrowhead.c:624:10: fatal error: 'numpy/arrayobject.h' file not found
#include "numpy/arrayobject.h"
         ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
error: Command "clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -I/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -Iarrow -I/usr/local/include -I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/sqlite/include -I/pathToArrow/arrow/venv/include -I/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/include/python3.7m -c arrow/arrowhead.c -o build/temp.macosx-10.15-x86_64-3.7/arrow/arrowhead.o" failed with exit status 1
make: *** [compile] Error 1
```

### After Fix

```
$ make clean
rm -rf arrow/arrowhead*.so arrow/arrowhead.c arrow/arrowhead.html build/ dist/ MANIFEST .pytest_cache/ stochastic_arrow.egg-info/
find . -name "*.pyc" -delete
find . -name "__pycache__" -delete
$ make compile
USE_CYTHON=1 python setup.py build_ext --inplace
Compiling arrow/arrowhead.pyx because it changed.
[1/1] Cythonizing arrow/arrowhead.pyx
running build_ext
building 'arrow.arrowhead' extension
C compiler: clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -I/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers

creating build
creating build/temp.macosx-10.15-x86_64-3.7
creating build/temp.macosx-10.15-x86_64-3.7/arrow
compile options: '-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -Iarrow -I/pathToArrow/arrow/venv/lib/python3.7/site-packages/numpy/core/include -I/usr/local/include -I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/sqlite/include -I/pathToArrow/arrow/venv/include -I/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/include/python3.7m -c'
clang: arrow/arrowhead.c
clang: arrow/mersenne.c
clang: arrow/obsidian.c
creating build/lib.macosx-10.15-x86_64-3.7
creating build/lib.macosx-10.15-x86_64-3.7/arrow
clang -bundle -undefined dynamic_lookup -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk build/temp.macosx-10.15-x86_64-3.7/arrow/arrowhead.o build/temp.macosx-10.15-x86_64-3.7/arrow/mersenne.o build/temp.macosx-10.15-x86_64-3.7/arrow/obsidian.o -L/usr/local/lib -L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/sqlite/lib -o build/lib.macosx-10.15-x86_64-3.7/arrow/arrowhead.cpython-37m-darwin.so
copying build/lib.macosx-10.15-x86_64-3.7/arrow/arrowhead.cpython-37m-darwin.so -> arrow
```