### PR TITLE
Release 0.5.1 for Python 3.11 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ More examples:
 
 ## Changelog
 
+### Version 0.5.1
+
+* Update to Cython 3.0.0a11 for compatibility with Python 3.11.
+  Add `arrow.pxd` to work around a Cython 3.0.0 bug.
+* Stop using deprecated `numpy.distutils` to avoid warnings and prepare for its
+  removal in Python 3.12.
+* Make `test_arrow.py --plot` compatible with Python 3.
+* Fix `PytestReturnNotNoneWarning` warnings from pytest 7.2.0.
+
 ### Version 0.5.0
 
 * Add the arrow_hang unit test which catches a nasty edge-case (Issue #48),

--- a/arrow/analysis/plotting.py
+++ b/arrow/analysis/plotting.py
@@ -7,7 +7,6 @@ matplotlib.
 
 from __future__ import absolute_import, division, print_function
 
-import matplotlib.pyplot as plt
 
 def plot_full_history(axes, time, counts, *args, **kwargs):
     '''

--- a/arrow/arrow.pxd
+++ b/arrow/arrow.pxd
@@ -1,0 +1,4 @@
+# cython: language_level=3str
+
+# This file works around a Cython 3.0.0a1+ error on arrowhead.pyx:
+#    arrow/arrowhead.pyx:14:0: 'arrow.pxd' not found

--- a/arrow/test/test_arrow.py
+++ b/arrow/test/test_arrow.py
@@ -312,11 +312,17 @@ def test_get_set_random_state():
 
 
 def main(args):
+    def check_stochastic_system():
+        return complexation_test(StochasticSystem)
+
+    def check_gillespie_reference():
+        return complexation_test(GillespieReference)
+
     systems = (
         check_equilibration,
         check_dimerization,
-        lambda: complexation_test(StochasticSystem),
-        lambda: complexation_test(GillespieReference))
+        check_stochastic_system,
+        check_gillespie_reference,)
 
     if not args.plot:
         if args.complexation:
@@ -359,7 +365,8 @@ def main(args):
         all_axes = np.asarray(all_axes)
 
         for (axes, system) in moves.zip(all_axes.flatten(), systems):
-            axes.set_title(system.func_name)
+            print(f'Running {system.__name__}')
+            axes.set_title(system.__name__)
 
             time, counts, events = system()
             plot_full_history(axes, time, counts)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
+# pip install -U -r requirements.txt
+
 pip
 setuptools
 
-Cython
+Cython>=3.0.0a11
 numpy
 pytest
 psutil

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,16 @@
 # See https://numpy.org/devdocs/reference/distutils_status_migration.html for
 # migration advice.
 # This setup.py file no longer uses numpy.distutils so it might be easy to
-# fully move to setuptools.
+# move fully to setuptools.
 
 import os
 import setuptools  # used indirectly for bdist_wheel cmd and long_description_content_type
 from distutils.core import setup
 from distutils.extension import Extension
 import numpy as np
+
+_ = setuptools
+
 
 with open("README.md", 'r') as readme:
     long_description = readme.read()


### PR DESCRIPTION
* Update to Cython 3.0.0a11 for Python 3.11 compatibility, and workaround a Cython 3.0.0a* bug.
* Fixes for Python 3.
* Fix `AttributeError: 'function' object has no attribute 'func_name'` in `test_arrow.py` by switching from Python 2-only `.func_name` to Python 2/3 `.__name__`, and using named functions.
* Fix `PytestReturnNotNoneWarning: Expected None, but [a test method] returned [a tuple]`.
* Stop using `numpy.distutils` which generates deprecation warnings about removal in Python 3.12.

The resulting `stochastic-arrow` package installs successfully in Python 3.8 and 3.11.

Python 3.9 - 3.11 have lots of performance improvements so it's worth updating wcEcoli and Vivarium to use it. `numba==0.57.0` is still in development for 3.11.

**Test failures that are probably not new**

`pytest` gets

    FAILED arrow/test/test_arrow.py::test_flagella - arrow.arrow.SimulationFailure

and sometimes

    FAILED arrow/test/test_arrow.py::test_memory - assert 5 <= 1

`python arrow/test/test_arrow.py --plot` gets

    ValueError: x and y must have same first dimension, but have shapes (115,) and (114, 2469)

`python arrow/test/test_arrow.py --flagella` gets

    arrow.arrow.SimulationFailure

[It looks like @prismofeverything is no longer a repo member.]